### PR TITLE
Make 'contact' variable a list of strings instead of a single string.

### DIFF
--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -203,15 +203,23 @@ def check_helpers(helpers):
 
 
 @look_for_fixme
-def check_email(email):
+def check_emails(emails):
     """
-    'contact' must be a valid email address consisting of characters,
-    an '@', and more characters.  It should not be the default contact
+    'contact' must be a comma-separated list of valid email addresses.
+    The list may be empty. A valid email address consists of characters,
+    an '@', and more characters.  It should not contain the default contact
     email address 'admin@software-carpentry.org'.
     """
 
-    return bool(re.match(EMAIL_PATTERN, email)) and \
-           (email != DEFAULT_CONTACT_EMAIL)
+    # YAML automatically loads list-like strings as lists.
+    if (isinstance(emails, list) and len(emails) >= 0):
+        for email in emails:
+            if ((not bool(re.match(EMAIL_PATTERN, email))) or (email == DEFAULT_CONTACT_EMAIL)):
+                return False
+    else:
+        return False
+
+    return True
 
 
 def check_eventbrite(eventbrite):
@@ -286,9 +294,10 @@ HANDLERS = {
                    'helper list isn\'t a valid list of format ' +
                    '["First helper", "Second helper",..]'),
 
-    'contact':    (True, check_email,
-                   'contact email invalid or still set to ' +
-                   '"{0}".'.format(DEFAULT_CONTACT_EMAIL)),
+    'contact':    (True, check_emails,
+                    'contact email list isn\'t a valid list of format ' +
+                    '["me@example.org", "you@example.org",..] or contains incorrectly formatted email addresses or ' +
+                     '"{0}".'.format(DEFAULT_CONTACT_EMAIL)),
 
     'eventbrite': (False, check_eventbrite, 'Eventbrite key appears invalid'),
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-
 enddate: FIXME        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["FIXME"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["FIXME"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
-contact: "FIXME"      # contact email address for host, lead instructor, or whoever else is handling questions
+contact: ["fixme@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 etherpad:             # optional: URL for the workshop Etherpad if there is one
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
@@ -148,9 +148,22 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
 
 <p id="contact">
   <strong>Contact</strong>:
-  Please mail
-  <a href="mailto:{{page.contact}}">{{page.contact}}</a> for more
-  information.
+  Please email
+  {% if page.contact %}
+    {% for contact in page.contact: %}
+      {% if forloop.last and page.contact.size > 1 %}
+        or
+      {% else %}
+        {% unless forloop.first %}
+        ,
+        {% endunless %}
+      {% endif %}
+      <a href='mailto:{{contact}}'>{{contact}}</a>
+    {% endfor %}
+  {% else %}
+    to-be-announced
+  {% endif %}
+  for more information.
 </p>
 
 <hr/>


### PR DESCRIPTION
The same issue was fixed for workshop-template (see https://github.com/swcarpentry/workshop-template/pull/362) but was not ported for training-template.