### PR TITLE
Removed mailto link from the accessibility paragraph to avoid repetition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
   large-print handouts are available if needed by notifying the
   organizers in advance.  If we can help making learning easier for
   you (e.g. sign-language interpreters, lactation facilities) please
-  <a href="mailto:{{page.contact}}">get in touch</a> and we will
+  please get in touch (using contact details below) and we will
   attempt to provide them.
 </p>
 


### PR DESCRIPTION
Point to the contact section instead.

Same issue as https://github.com/swcarpentry/workshop-template/issues/414 