### PR TITLE
Make link to materials and schedule more obvious

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,8 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
 
 <hr/>
 
+<h2 id="materials" name="materials">Training Materials and Schedule</h2>
+
 <p>
   Please see <a href="{{ site.training_site }}">this site</a> for course material and for the schedule.
 </p>

--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
 <h2 id="materials" name="materials">Training Materials and Schedule</h2>
 
 <p>
-  Please see <a href="{{ site.training_site }}">this site</a> for course material and for the schedule.
+  Please see <a href="{{ site.training_site }}">this site</a> for course material and tentative schedule.
 </p>
 
 


### PR DESCRIPTION
I was used to having schedule in this workshop template, which was changed to a link to schedule in instructor training material. I missed out on the link initially, so created a heading to make it more prominent.