### PR TITLE
Add post-assessment survey link

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,4 +278,8 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
   <br/>
   We will use this Etherpad for chatting, taking notes, and sharing URLs and bits of code.
 </p>
+
+<p>
+  After the workshop, please fill out <a href="https://carpentries.github.io/instructor-training/06-feedback/#surveys">our post-assessment survey</a>.
+</p>
 {% endif %}


### PR DESCRIPTION
As requested in https://github.com/carpentries/instructor-training/issues/652