### PR TITLE
WIP -- [Fix #18] Make workshop venues more modular

### DIFF
--- a/_includes/workshop_ad.html
+++ b/_includes/workshop_ad.html
@@ -1,9 +1,10 @@
 <div class="jumbotron">
   <div class="row">
     <div class="col-md-10 col-md-offset-1">
-      <h2>{{page.venue}}</h2>
+      <h2>Instructor Training</h2>
       <div class="row">
         <div class="col-md-6">
+	  <p>{% for loc in page.locations %}{{ loc.venue }}{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
           <p>{{page.humandate}}</p>
           <p>{% if page.humantime %}{{page.humantime}}{% endif %}</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,8 @@
 ---
 layout: workshop      # DON'T CHANGE THIS.
 root: .               # DON'T CHANGE THIS EITHER.  (THANK YOU.)
-carpentry: "FIXME"    # what kind of Carpentry (must be either "dc" or "swc")
-venue: "FIXME"        # brief name of host site without address (e.g., "Euphoric State University")
-address: "FIXME"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
 country: "FIXME"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1)
 language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/ISO_639-1)
-latlng: "FIXME"       # decimal latitude and longitude of workshop venue (e.g., "41.7901128,-87.6007318" - use http://www.latlong.net/)
 humandate: "FIXME"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
 humantime: "FIXME"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
 startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
@@ -16,6 +12,14 @@ helper: ["FIXME"]     # boxed, comma-separated list of helpers' names, like ["Ma
 contact: ["fixme@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 etherpad:             # optional: URL for the workshop Etherpad if there is one
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
+locations:
+  - venue: "Online"
+    address: "https://carpentries.zoom.us/j/FIXME"
+
+  - venue: "Euphoria University"
+    address: "Room A, 123 Forth Street, Blimingen, Euphoria"
+    latlng: "41.7901128,-87.6007318"
+
 ---
 
 <!-- See instructions in the comments below for how to edit specific sections of this workshop template. -->
@@ -94,62 +98,78 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
   if the latitude and longitude of the workshop have been set.  You
   can use http://itouchmap.com/latlong.html to find the lat/long of an
   address.
--->
-{% if page.latlng %}
-<p id="where">
-  <strong>Where:</strong>
-  {{page.address}}.
-  Get directions with
-  <a href="//www.openstreetmap.org/?mlat={{page.latlng | replace:',','&mlon='}}&zoom=16">OpenStreetMap</a>
-  or
-  <a href="//maps.google.com/maps?q={{page.latlng}}">Google Maps</a>.
-</p>
+  -->
+<h3 id="where">Where</h3>
+
+{% assign inperson = "false" %}
+{% for loc in page.locations %}
+
+{% capture online %}{{ loc.venue | downcase }}{% endcapture %}
+
+<h4>{{ loc.venue }}</h4>
+
+{% if online == "online" %}
+
+This is an online event. We will meet using the online videoconference software Zoom. You will need to <a href="https://zoom.us/download">download and install their client</a> to connect with your instructors. The link to use for this event is <{{ loc.address }}>.
+
+{% else %}
+{% assign inperson = "true" %}
+{{ loc.address }} {% if loc.latlng %} Get directions with
+    <a href="//www.openstreetmap.org/?mlat={{loc.latlng | replace:',','&mlon='}}&zoom=16">OpenStreetMap</a>
+    or
+    <a href="//maps.google.com/maps?q={{loc.latlng}}">Google Maps</a>. {% endif %}
+
 {% endif %}
+{% endfor %}
 
-<p>
-  <strong>Requirements:</strong> Participants should bring a laptop
-  that is Internet connected and has a functioning browser.  If you
-  have it, a device for recording audio and video (mobile phones and
-  laptops are OK) is useful as throughout the two days, we are going
-  to record one another teaching in pairs or threes.  It does not have
-  to be high-quality, but it should be good enough that you can
-  understand what someone is saying.
-</p>
-<p>
-  Please note that after this course is over, you will be asked to do
-  three short follow-up exercises online in order to finish qualifying
-  as an instructor: the details are available at
-  <a href="{{ site.training_site }}/checkout/">{{ site.training_site }}/checkout/</a>.
-  If you have any questions about the workshop, the reading material,
-  or anything else, please get in touch.
-</p>
-<p align="center">
-  <em>
-    All participants are required to abide by Software
-    Carpentry's <a href="{{ site.swc_site }}/conduct/">Code of Conduct</a>.
-  </em>
-</p>
+{% if inperson == "true" %}
 
-<p id="accessibility">
-  <strong>Accessibility:</strong> We are committed to making this workshop
-  accessible to everybody.
-  The workshop organisers have checked that:
-</p>
+<h4 id="accessibility">Accessibility</h4>
+
+We are committed to making this workshop
+accessible to everybody.
+The workshop organisers have checked that:
+
 <ul>
   <li>The room is wheelchair / scooter accessible.</li>
   <li>Accessible restrooms are available.</li>
 </ul>
-<p>
+
   Materials will be provided in advance of the workshop and
   large-print handouts are available if needed by notifying the
   organizers in advance.  If we can help making learning easier for
   you (e.g. sign-language interpreters, lactation facilities) please
   please get in touch (using contact details below) and we will
   attempt to provide them.
-</p>
 
-<p id="contact">
-  <strong>Contact</strong>:
+{% endif %}
+
+<h3>Requirements</h3>
+
+Participants should bring a laptop that is Internet connected and has a
+  functioning browser. If you have it, a device for recording audio and video
+  (mobile phones and laptops are OK) is useful as throughout the two days, we
+  are going to record one another teaching in pairs or threes. It does not have
+  to be high-quality, but it should be good enough that you can understand what
+  someone is saying.
+
+  Please note that after this course is over, you will be asked to do
+  three short follow-up exercises online in order to finish qualifying
+  as an instructor: the details are available at
+  <a href="{{ site.training_site }}/checkout/">{{ site.training_site }}/checkout/</a>.
+  If you have any questions about the workshop, the reading material,
+  or anything else, please get in touch.
+
+
+<h3>Code of Conduct</h3>
+
+All participants are required to abide by Software Carpentry's <a href="{{
+site.swc_site }}/conduct/">Code of Conduct</a>.
+
+
+
+<h3 id="contact">Contact</h3>
+
   Please email
   {% if page.contact %}
     {% for contact in page.contact %}


### PR DESCRIPTION
As mentioned in #18, given that instructor training can be: in person, online, or both, we need to adjust the template to take this into account.

Here I propose to create an entry in the YAML file "locations" that is flexible enough to deal with these 3 situations. (screenshots below)

If it's an online event, the `locations` entry would look like:

```yaml
locations:
  - venue: "Online"
    address: "https://carpentries.zoom.us/j/FIXME"
```

If it's an in person event, the `locations` entry would look like:

```yaml
locations:
   - venue: "Euphoria University"
     address: "Room A, 123 Forth Street, Blimingen, Euphoria"
     latlng: "0,0"
```

and in case of hybrid training:

```yaml
locations:
  - venue: "Online"
    address: "https://carpentries.zoom.us/j/FIXME"
  - venue: "Euphoria University"
    address: "Room A, 123 Forth Street, Blimingen, Euphoria"
    latlng: "0,0"
  - venue: "South Pole University"
    address: "Room 100, Midnight sun Blvd, South Pole"
    latlng: "-90,0"
```

Online only:
![screenshot from 2018-04-30 16-46-36](https://user-images.githubusercontent.com/5502922/39449585-79b45816-4c96-11e8-89de-6de8c4491a58.png)


In person only:
![screenshot from 2018-04-30 16-47-00](https://user-images.githubusercontent.com/5502922/39449583-79a28096-4c96-11e8-90e8-162b67e7b4e7.png)

Hybrid:
![screenshot from 2018-04-30 16-47-55](https://user-images.githubusercontent.com/5502922/39449581-797cbfaa-4c96-11e8-95ff-49b31090565a.png)
