### PR TITLE
Change index.html to index.md in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ template for creating websites for Instructor Training workshops.
 
 3.  Once you are done,
     please **send your repository's URL to [The Carpentries' administrator][contact]**.
-    We build the list of workshops on our websites from the data included in your `index.html` page.
+    We build the list of workshops on our websites from the data included in your `index.md` page.
     We can only do that if you [customize][customization] that page correctly
     *and* send us a link to your workshop website.
 
@@ -71,20 +71,20 @@ please [get in touch](#getting-and-giving-help).
     if your username is `gvwilson`,
     the repository's URL will be `https://github.com/gvwilson/2016-12-01-ttt-miskatonic`.
 
-2.  Edit the header of `index.html` and `_config.yml` to customize the list of instructors,
-    workshop venue, etc. 
+2.  Edit the header of `index.md` and `_config.yml` to customize the list of instructors,
+    workshop venue, etc.
     You can do this in the browser by clicking on it in the file view on GitHub
     and then selecting the pencil icon in the menu bar:
 
     ![](fig/edit-index-file-menu-bar.png?raw=true)
-    
-    Editing hints are embedded in `index.html` and `_config.yml`,
+
+    Editing hints are embedded in `index.md` and `_config.yml`,
     and full instructions are in [the customization instructions][customization].
 
 3.  Alternatively,
     if you are already familiar with Git,
     you can clone the repository to your desktop,
-    edit `index.html` there,
+    edit `index.md` there,
     and push your changes back to the repository.
 
     ~~~
@@ -136,7 +136,7 @@ you can do so as described below.
     You can also run this command by typing `make serve`
     (if you have Make installed).
 
-3.  Run the command `python bin/workshop_check.py index.html`
+3.  Run the command `python bin/workshop_check.py index.md`
     to check for a few common errors in your workshop's home page.
     (You must have Python 3 installed to do this.)
     If you have Make installed,
@@ -160,7 +160,7 @@ you *must* also edit `_config.yml` to set these three values:
 3.  `email` is the contact email address for your workshop,
     e.g., `gvwilson@miskatonic.edu`.
 
-Note: `carpentry and `email` duplicate information that's in `index.html`,
+Note: `carpentry and `email` duplicate information that's in `index.md`,
 but there is no way to avoid this
 without requiring people to edit both files in the usual case
 where no extra pages are created.

--- a/_extras/customization.md
+++ b/_extras/customization.md
@@ -15,7 +15,7 @@ You should not need to modify any of the other values in `_config.yml`.
 
 ## Home Page: Data
 
-Your workshop's home page lives in `index.html`,
+Your workshop's home page lives in `index.md`,
 which must define the following values in its header:
 
 *   `layout` must be `workshop`.
@@ -115,7 +115,7 @@ so that learners don't spend time installing software they don't need.
 ## Setup: Installation tests
 
 If you intend to use the installation-test scripts,
-uncomment the paragraph linking to `setup/index.html` in `index.html`
+uncomment the paragraph linking to `setup/index.html` in `index.md`
 and edit `setup/swc-installation-test-2.py` as described below.
 
 `swc-installation-test-1.py` is pretty simple, and just checks that

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -74,7 +74,7 @@ than Git itself.
     their pages has to be stored in `_includes`.
 
 9.  A repository can have another special directory called `_layouts`.
-    If a page like `index.html` has a variable called `layout`, and
+    If a page like `index.md` has a variable called `layout`, and
     that variable's value is `standard.html`, Jekyll loads the file
     `_layouts/standard.html` and copies the content of `index.html`
     into it, then expands the result.  This is used to give the pages
@@ -82,8 +82,8 @@ than Git itself.
     We have created two layouts for workshop pages:
 
     * `workshop.html` is used for workshops' home pages, and is the
-      layout for the `index.html` page in your repo's root directory.
-      That `index.html` page's header must define several variables as
+      layout for the `index.md` page in your repo's root directory.
+      That `index.md` page's header must define several variables as
       specified in the the customization instructions in order for
       your workshop to be included in our main website.
 

--- a/_extras/faq.md
+++ b/_extras/faq.md
@@ -12,7 +12,7 @@ permalink: /faq/
     and ask for help there.
 
 *What if I can't wait?*
-:   Run `make workshop-check` to run the workshop homepage checking program on `index.html`.
+:   Run `make workshop-check` to run the workshop homepage checking program on `index.md`.
 
 *Where can I report problems or suggest improvements?*
 :   Please file an issue against [{{site.workshop_repo}}](this repository)
@@ -42,7 +42,7 @@ permalink: /faq/
 :   Use subdirectories like `2015-07-01-esu/beginners`,
     so that repository names always follow our four-part convention.
 
-*What if I want to add more values to `index.html`, like `address1` and `address2` for different rooms on different days?*
+*What if I want to add more values to `index.md`, like `address1` and `address2` for different rooms on different days?*
 :   Go ahead,
     but you *must* have the variables described in the customization instructions.
 
@@ -59,7 +59,7 @@ permalink: /faq/
 ## Debugging
 
 *Help, my website is not updating!*
-:   Ensure that strings in the header of `index.html` are enclosed in quotations `"`.
+:   Ensure that strings in the header of `index.md` are enclosed in quotations `"`.
     Special characters such as `"&"` may render correctly on your local machine
     but cause rendering to fail silently on GitHub.
 
@@ -70,7 +70,7 @@ permalink: /faq/
     eventbrite: 1234567890AB
     ~~~
 
-    in the YAML header of `index.html`.
+    in the YAML header of `index.md`.
     If the YAML header is set properly you may be accessing
     `file:///home/to/workshop/directory/_site/index.html` directly.
     Instead,

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-'''Check that a workshop's index.html metadata is valid.  See the
+'''Check that a workshop's index.md metadata is valid.  See the
 docstrings on the checking functions for a summary of the checks.
 '''
 
@@ -404,7 +404,7 @@ def main():
         sys.exit(1)
 
     root_dir = sys.argv[1]
-    index_file = os.path.join(root_dir, 'index.html')
+    index_file = os.path.join(root_dir, 'index.md')
     config_file = os.path.join(root_dir, '_config.yml')
 
     reporter = Reporter()


### PR DESCRIPTION
The instructions in the README refer to `index.html` while we now use `index.md`. This PR adjusts the instances where this seems to be wrong. Looks like I got all of them, but maybe someone should check this...