### PR TITLE
Fix for inconsistent pre and post survey links #47

### DIFF
--- a/index.md
+++ b/index.md
@@ -298,5 +298,5 @@ for more information.
 
 
 <p>
-  After the workshop, please fill out <a href="https://carpentries.github.io/instructor-training/06-feedback/#surveys">our post-assessment survey</a>.
+  After the workshop, please fill out <a href="{{ site.instructor_post_survey }}{{ site.github.project_title }}">our post-training survey</a>.
 </p>


### PR DESCRIPTION
Fixed post-instructor-training workshop survey link, see: https://github.com/carpentries/training-template/issues/47