### PR TITLE
Update science of learning link

### DIFF
--- a/index.md
+++ b/index.md
@@ -163,7 +163,7 @@ Before your training, please visit our Preparing for Instructor Training page fo
   <li>Select a lesson to use for teaching practice sessions and prepare a 3 minute segment, spending no more than 20-30 minutes to prepare.</li>
   <li>Please read the following:</li>
     <ul>
-      <li><a href="{{ site.training_site }}/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
+      <li><a href="https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
       <li><a href="https://carpentries.org/files/reports/Carpentries2020AnnualReport.pdf">The Carpentries Annual Report</a></li>
     </ul> 
 </ol> 

--- a/index.md
+++ b/index.md
@@ -163,7 +163,7 @@ Before your training, please visit our Preparing for Instructor Training page fo
   <li>Select a lesson to use for teaching practice sessions and prepare a 3 minute segment, spending no more than 20-30 minutes to prepare.</li>
   <li>Please read the following:</li>
     <ul>
-      <li><a href="{{ page.training_site }}/files/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
+      <li><a href="{{ site.training_site }}/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
       <li><a href="https://carpentries.org/files/reports/Carpentries2020AnnualReport.pdf">The Carpentries Annual Report</a></li>
     </ul> 
 </ol> 


### PR DESCRIPTION
Updated to be consistent, referencing the Carpentries site, not the specific training page (since when forked, the paper isn't always hosted on the page)

Something I noticed when undergoing Instructor Training, so don't have full context and solution might be imperfect.