### PR TITLE
Configuration for online trainings

### DIFF
--- a/index.md
+++ b/index.md
@@ -178,6 +178,7 @@ Before your training, please visit our Preparing for Instructor Training page fo
 After the training event, we ask you to complete three follow-up tasks to become a certified Instructor. These requirements are detailed on our
   <a href="{{ site.training_site }}/checkout/">Checkout Instructions</a> page and will be discussed at our training.
 
+{% if online == "false" %}
 <h3>What to Bring to an In-Person Event</h3>
 
 Participants should bring a laptop that is Internet connected and has a
@@ -186,6 +187,7 @@ functioning browser. If you have it, a device for recording audio and video
 are going to record one another teaching in pairs or threes. It does not have
 to be high-quality, but it should be good enough that you can understand what
 someone is saying.
+{% endif %}
 
 <h3>Attendance and Cancellation</h3>
 Trainees who miss more than 1 hour of the training may be marked absent.

--- a/index.md
+++ b/index.md
@@ -1,25 +1,21 @@
 ---
 layout: workshop      # DON'T CHANGE THIS.
 root: .               # DON'T CHANGE THIS EITHER.  (THANK YOU.)
+venue: "FIXME"        # brief name of the institution that hosts the workshop without address (e.g., "Euphoric State University")
+address: "FIXME"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria"), videoconferencing URL, or 'online'
 country: "FIXME"      # "W3" for centrally organized online trainings or lowercase two-letter ISO country code such as "fr" of the host institution if applicable (see https://en.wikipedia.org/wiki/ISO_3166-1)
 language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/ISO_639-1)
+latitude: "45"        # decimal latitude of training venue (use https://www.latlong.net/)
+longitude: "-1"       # decimal longitude of the training venue (use https://www.latlong.net)
 humandate: "FIXME"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
 humantime: "FIXME"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
 startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: FIXME        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
-instructor: ["FIXME"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
+instructor: ["FIXME"] # boxed, comma-separated list of trainers' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["FIXME"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 contact: ["fixme@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 etherpad:             # optional: URL for the workshop Etherpad if there is one
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
-locations:            # for online events, delete the second section below. for in-person events, customize the second section and delete the first section.
-  - venue: "Online" 
-    address: ""
-
-  - venue: "Euphoria University" 
-    address: "Room A, 123 Forth Street, Blimingen, Euphoria"
-    latlng: "41.7901128,-87.6007318"
-
 ---
 
 <!-- See instructions in the comments below for how to edit specific sections of this workshop template. -->
@@ -61,35 +57,35 @@ locations:            # for online events, delete the second section below. for 
 -->
 
 <p>
-<a href="{{ www.carpentries.org }}">The Carpentries</a> is a community of practice centered around teaching foundational 
-  coding and data science skills to researchers worldwide. This Instructor Training 
-  event is designed to prepare trainees to certify and participate as Carpentries 
-  Instructors. However, much of our curriculum focuses on educational principles that 
-  apply across a wide variety of contexts. We also welcome participants who do not plan 
+<a href="{{ www.carpentries.org }}">The Carpentries</a> is a community of practice centered around teaching foundational
+  coding and data science skills to researchers worldwide. This Instructor Training
+  event is designed to prepare trainees to certify and participate as Carpentries
+  Instructors. However, much of our curriculum focuses on educational principles that
+  apply across a wide variety of contexts. We also welcome participants who do not plan
   to certify but simply wish to become a better teacher.
 </p>
 
 <p>Carpentries Instructor Training has the following goals:</p>
-  
+
 * Introduce you to evidence-based teaching practices.
 * Teach you how to create a positive environment for learners at your workshops.
 * Provide opportunities for you to practice and build your teaching skills.
 * Help you become integrated into the Carpentries community.
 * Prepare you to use these teaching skills in teaching Carpentries workshops.
-  
+
 <p> Because we have only limited time, some things are beyond the scope of this training. We will
 not be learning:</p>
-  
-* How to program in R or Python, use Git or SQL, or any of the other topics taught in  <a href="{{ site.dc_site }}">Data Carpentry</a>, 
-  <a href="{{ site.lc_site }}">Library Carpentry</a>, or 
+
+* How to program in R or Python, use Git or SQL, or any of the other topics taught in  <a href="{{ site.dc_site }}">Data Carpentry</a>,
+  <a href="{{ site.lc_site }}">Library Carpentry</a>, or
   <a href="{{ site.swc_site }}">Software Carpentry</a> workshops.
 * How to create your own lessons from scratch (although you will have a good start on the principles behind that sort of work if you are inspired to learn more).
 
 
 <p>
-Instructor Training events are hands-on throughout: short lessons alternate 
-with individual and group practical exercises, including practice teaching sessions. 
-This Instructor Training event is the first step towards certification as a 
+Instructor Training events are hands-on throughout: short lessons alternate
+with individual and group practical exercises, including practice teaching sessions.
+This Instructor Training event is the first step towards certification as a
 Carpentries Instructor. For more details on the other 3 steps, see the <a href="{{ site.training_site }}/checkout/">Checkout Instructions</a> page.
 For more information, see our <a href="{{ site.training_site }}">Instructor Training Curriculum</a>.
 </p>
@@ -100,6 +96,15 @@ All participants are required to abide by The Carpentries <a href="{{
 site.swc_site }}/conduct/">Code of Conduct</a>.
 
 
+
+{% assign begin_address = page.address | slice: 0, 4 | downcase  %}
+{% if page.address == "online" %}
+{% assign online = "true_private" %}
+{% elsif begin_address contains "http" %}
+{% assign online = "true_public" %}
+{% else %}
+{% assign online = "false" %}
+{% endif %}
 <!--
   LOCATION
 
@@ -110,32 +115,33 @@ site.swc_site }}/conduct/">Code of Conduct</a>.
   -->
 <h3 id="where">Where</h3>
 
-{% assign inperson = "false" %}
-{% for loc in page.locations %}
-
-{% capture online %}{{ loc.venue | downcase }}{% endcapture %}
-
-<h4>{{ loc.venue }}</h4>
-
-{% if online == "online" %}
-
-This is an online event and will be conducted using the Zoom video conferencing platform. No log-in is needed. 
-However, if you have not used Zoom before, please click the link a few minutes early as it may prompt you to 
-install the Zoom app or browser extension. You should have received a connection link in the same email that 
-directed you to this website. If you found this page by another means and did not receive the connection link, 
-please check your spam folder and email instructor.training@carpentries.org with your Trainers (contact details below) on cc.
-
-{% else %}
-{% assign inperson = "true" %}
-{{ loc.address }} {% if loc.latlng %} Get directions with
-    <a href="//www.openstreetmap.org/?mlat={{loc.latlng | replace:',','&mlon='}}&zoom=16">OpenStreetMap</a>
-    or
-    <a href="//maps.google.com/maps?q={{loc.latlng}}">Google Maps</a>. {% endif %}
-
+{% if online == "false" %}
+<p id="venue">
+  {{page.address}}.
+  {% if page.latitude and page.longitude %}
+  Get directions with
+  <a href="//www.openstreetmap.org/?mlat={{page.latitude}}&mlon={{page.longitude}}&zoom=16">OpenStreetMap</a>
+  or
+  <a href="//maps.google.com/maps?q={{page.latitude}},{{page.longitude}}">Google Maps</a>.
+  {% endif %}
+</p>
+{% elsif online == "true_public" %}
+<p id="venue">
+  Online at <a href="{{page.address}}">{{page.address}}</a>.
+  The training will be conducted using the Zoom video conferencing platform. No log-in is needed.
+  However, if you have not used Zoom before, please click the link a few minutes early as it may prompt you to
+  install the Zoom app or browser extension. You should have received a connection link in the same email that
+  directed you to this website. If you found this page by another means and did not receive the connection link,
+  please check your spam folder and email instructor.training@carpentries.org with your Trainers (contact details below) on cc.
+</p>
+{% elsif online == "true_private" %}
+<p id="venue">
+  This training will take place online.
+  The instructors will provide you with the information you will need to connect to this meeting.
+</p>
 {% endif %}
-{% endfor %}
 
-{% if inperson == "true" %}
+{% if online == "false" %}
 
 <h4 id="accessibility">Accessibility</h4>
 
@@ -148,15 +154,15 @@ Workshop organisers have checked that:
   <li>Accessible restrooms are available.</li>
 </ul>
 
-Materials will be provided in advance of the workshop. 
-If we can help make learning easier for you in any way by 
-providing additional support, accommodations, or assistance, 
+Materials will be provided in advance of the workshop.
+If we can help make learning easier for you in any way by
+providing additional support, accommodations, or assistance,
 please get in touch (using contact details below) and we will attempt to provide them.
 
 {% endif %}
 
 <h3>How to Prepare for Instructor Training</h3>
-  
+
 Before your training, please visit our Preparing for Instructor Training page for complete instructions. A brief summary of these instructions is as follows
 <ol>
   <li>Complete our Pre-training Survey. You will receive a custom link for your event when you receive your connection information.</li>
@@ -165,13 +171,13 @@ Before your training, please visit our Preparing for Instructor Training page fo
     <ul>
       <li><a href="https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
       <li><a href="https://carpentries.org/files/reports/2021%20Carpentries%20Annual%20Report_Final.pdf">The Carpentries Annual Report</a></li>
-    </ul> 
-</ol> 
+    </ul>
+</ol>
 
 <h3> Checkout: The Instructor Certification Process</h3>
-After the training event, we ask you to complete three follow-up tasks to become a certified Instructor. These requirements are detailed on our 
-  <a href="{{ site.training_site }}/checkout/">Checkout Instructions</a> page and will be discussed at our training. 
-  
+After the training event, we ask you to complete three follow-up tasks to become a certified Instructor. These requirements are detailed on our
+  <a href="{{ site.training_site }}/checkout/">Checkout Instructions</a> page and will be discussed at our training.
+
 <h3>What to Bring to an In-Person Event</h3>
 
 Participants should bring a laptop that is Internet connected and has a
@@ -182,14 +188,14 @@ to be high-quality, but it should be good enough that you can understand what
 someone is saying.
 
 <h3>Attendance and Cancellation</h3>
-Trainees who miss more than 1 hour of the training may be marked absent. 
-Instructor certification cannot be completed without full attendance at 
-an Instructor Training event. If you unexpectedly need to miss more than 
-1 hour of your event, please contact your Trainers (contact info below). 
+Trainees who miss more than 1 hour of the training may be marked absent.
+Instructor certification cannot be completed without full attendance at
+an Instructor Training event. If you unexpectedly need to miss more than
+1 hour of your event, please contact your Trainers (contact info below).
 
-For events in which registration occurs through The Carpentries via Eventbrite, 
-cancellation may be performed in Eventbrite up to the start of the event. 
-Canceled seats cannot be filled after the 1 week registration deadline for these events, 
+For events in which registration occurs through The Carpentries via Eventbrite,
+cancellation may be performed in Eventbrite up to the start of the event.
+Canceled seats cannot be filled after the 1 week registration deadline for these events,
 so we ask that you only cancel if absolutely necessary.
 
 More information on our <a href="https://docs.carpentries.org/topic_folders/instructor_training/cancellations_and_makeups.html">cancellation and makeup policy</a> is available in The Carpentries Handbook.
@@ -226,7 +232,7 @@ for more information.
   <li><a href="https://carpentries.org/files/reports/2021%20Carpentries%20Annual%20Report_Final.pdf">The Carpentries 2021 Annual Report</a></li>
 </ol>
 <p>
-  Please also read through <em>one</em> episode of one of The Carpentries lessons below   
+  Please also read through <em>one</em> episode of one of The Carpentries lessons below
   carefully, so that you can do some exercises based on it on the
   first day of the class.  An episode is one page of a lesson.
 </p>
@@ -236,7 +242,7 @@ for more information.
   <li><a href="{{ site.lc_site }}/lessons">Library Carpentry Lessons</a></li>
   <li><a href="{{ site.swc_site }}/lessons">Software Carpentry Lessons</a></li>
   </ul>
-  
+
 
 <hr/>
 
@@ -250,10 +256,10 @@ for more information.
 <hr/>
 
 <!--
-NOTE: This space can be customized to reflect the unique schedule of your workshop. If you would like it to display, 
+NOTE: This space can be customized to reflect the unique schedule of your workshop. If you would like it to display,
 adjust the times and titles, then delete the characters above and below that serve to comment it out.
 -->
-  
+
 <!--
 TWO DAY SCHEDULE
 --->


### PR DESCRIPTION
Resolves #56 by adjusting the configuration for online & in-person workshops:

1. Makes this configuration consistent with how it is done in carpentries/workshop-template
2. Toggles off the note about recording equipment for online workshops, so that this advice only appears for in-person events.