### PR TITLE
fix link to carpentries home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -61,7 +61,7 @@ locations:            # for online events, delete the second section below. for 
 -->
 
 <p>
-<a href="{{ www.carpentries.org }}">The Carpentries</a> is a community of practice centered around teaching foundational 
+<a href="{{ site.carpentries_site }}">The Carpentries</a> is a community of practice centered around teaching foundational 
   coding and data science skills to researchers worldwide. This Instructor Training 
   event is designed to prepare trainees to certify and participate as Carpentries 
   Instructors. However, much of our curriculum focuses on educational principles that 


### PR DESCRIPTION
This link to carpentries.org in the introductory paragraph was not working as intended. This PR fixes the problem by adjusting the target.