### PR TITLE
Alternative approach to add Lesson Developer Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,20 @@ but modify the `index.md.cldt` file instead.)
     git push origin gh-pages
     ~~~
 
-7.  When you are done editing,
+7. (Collaborative Lesson Development Training events only)
+    Rename `index.md.cldt` to `index.md` (replacing the original `index.md`)
+    to use this file as the source of the training event page.
+    If you are working locally, this can be achieved with the command
+    `git mv index.md.cldt index.md`.
+
+8.  When you are done editing,
     go to the GitHub Pages URL for your workshop and preview your changes.
     In the example above, this is `https://gvwilson.github.io/2016-12-01-ttt-oomza`.
     The finished page should look [something like this](fig/completed-page.png?raw=true).
 
-8.  Optional: you can now change the `README.md` file in your website's repository, which contains these instructions, so that it contains a short description of your workshop and a link to the training website.
+9.  Optional: you can now change the `README.md` file in your website's repository, which contains these instructions, so that it contains a short description of your workshop and a link to the training website.
 
-9.  Optional: Add a link to your workshop website on the repository main page in the description/website section (look for the `Edit` button on the right to add).
+10.  Optional: Add a link to your workshop website on the repository main page in the description/website section (look for the `Edit` button on the right to add).
 
 **Note:**
 please do all of your work in your repository's `gh-pages` branch,

--- a/README.md
+++ b/README.md
@@ -7,21 +7,27 @@ template for creating websites for Instructor Training workshops.
     Instead, please use [the instructions below](#creating-a-repository)
     to copy this `training-template` repository and customize it for your workshop.
 
-2.  Please *do your work in your repository's `gh-pages` branch*,
+2.  Customise the values in `_config.yml` and the header of `index.md`
+    (or `index.md.cldt` for Collaborative Lesson Development Training)
+    to configure the website for your training event.
+    Please *do your work in your repository's `gh-pages` branch*,
     since that is what is
     [automatically published as a website by GitHub][github-project-pages].
 
-3.  Once you are done,
-    please **send your repository's URL to [The Carpentries' administrator][contact]**.
-    We build the list of workshops on our websites from the data included in your `index.md` page.
-    We can only do that if you [customize][customization] that page correctly
-    *and* send us a link to your workshop website.
+3. (Collaborative Lesson Development Training events only)
+   Rename `index.md.cldt` to `index.md` (replacing the original `index.md`)
+   to use this file as the source of the training event page.
+
+4.  Once you are done,
+    please **send your repository's URL to The Carpentries contact]**.
+    For an Instructor Training event send the URL to <instructor.training@carpentries.org>.
+    For Collaborative Lesson Development Training, send to <curriculum@carpentries.org>.
 
 If you run into problems,
 or have ideas about how to make this process simpler,
 please [get in touch](#getting-and-giving-help).
 The section on [customizing your website][customization],
-and the [FAQ][faq] and [design notes][design] from the related template fore workshop websites
+and the [FAQ][faq] and [design notes][design] from the related template for workshop websites
 have more detail on what we do and why.
 
 ## Creating a Repository
@@ -39,10 +45,15 @@ have more detail on what we do and why.
     (This will probably be you, but may instead be an organization you belong to.)
 
 4.  Choose a name for your workshop website repository.
-    This name should have the form `YYYY-MM-DD-ttt-site`,
+    For **Instructor Training**, this name should have the form `YYYY-MM-DD-ttt-site`,
     e.g., `2016-12-01-ttt-oomza`,
-    where `YYYY-MM-DD` is the start date of the workshop.
-   For online workshops, choose `online` as `site`.
+    where `YYYY-MM-DD` is the start date of the training.
+    For **Collaborative Lesson Development Training**,
+    the name should have the form `YYYY-MM-DD-cldt-partN-site`,
+    where `YYYY-MM-DD` is the start date of the training
+    and `N` is a number indicating the part of the training (1 or 2)
+    that will be taught at this event.
+    For online workshops, choose `online` as `site`.
     In most cases, the Instructor Training Team will tell you
     the name of the repository you should use.
 
@@ -50,10 +61,14 @@ have more detail on what we do and why.
     repository from template". You will be redirected to your new copy of the workshop template
     respository.
 
-6. Your new website will be rendered at `https://your_username.github.io/YYYY-MM-DD-ttt-site`.
+6. With a repository called `YYYY-MM-DD-ttt-site`,
+   your new website will be rendered at `https://your_username.github.io/YYYY-MM-DD-ttt-site`.
 
 
 ## Customizing Your Website
+
+(For Collaborative Lesson Development Training, follow the steps described here
+but modify the `index.md.cldt` file instead.)
 
 1.  Go into your newly-created repository,
     which will be at `https://github.com/your_username/YYYY-MM-DD-ttt-site`.
@@ -83,7 +98,7 @@ have more detail on what we do and why.
     and push your changes back to the repository.
 
     ~~~
-    git clone -b gh-pages https://github.com/your_username/YYYY-MM-DD-ttt-site
+    git clone https://github.com/your_username/YYYY-MM-DD-ttt-site
     ~~~
 
     You should specify `-b gh-pages` to checkout the gh-pages branch because the imported

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,7 @@ swc_pages: "https://swcarpentry.github.io"
 swc_site: "https://software-carpentry.org"
 template_repo: "https://github.com/carpentries/styles"
 training_site: "https://carpentries.github.io/instructor-training"
+lessondev_training_site: "https://carpentries.github.io/lesson-development-training"
 workshop_repo: "https://github.com/carpentries/workshop-template"
 workshop_site: "https://carpentries.github.io/workshop-template"
 cc_by_human: "https://creativecommons.org/licenses/by/4.0/"
@@ -51,6 +52,8 @@ pre_survey: "https://carpentries.typeform.com/to/wi32rS#slug="
 post_survey: "https://carpentries.typeform.com/to/UgVdRQ#slug="
 instructor_pre_survey: "https://carpentries.typeform.com/to/QVOarK#slug="
 instructor_post_survey: "https://carpentries.typeform.com/to/cjJ9UP#slug="
+lessondev_pre_survey: FIXME
+lessondev_pre_survey: FIXME
 
 # Set to 'true' for instructor training websites only.
 instructor_training: false

--- a/_includes/workshop_ad.html
+++ b/_includes/workshop_ad.html
@@ -4,7 +4,7 @@
 <div class="jumbotron">
   <div class="row">
     <div class="col-md-10 col-md-offset-1">
-      <h2>Instructor Training</h2>
+      <h2>{{ page.curriculum }}</h2>
       <div class="row">
         <div class="col-md-6">
 	  <p>{% for loc in page.locations %}{{ loc.venue }}{% unless forloop.last %}, {% endunless %}{% endfor %}</p>

--- a/fig/CLDT-hex-sticker.svg
+++ b/fig/CLDT-hex-sticker.svg
@@ -1,0 +1,658 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg2439"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)"
+   sodipodi:docname="CLDT-hex-sticker.svg">
+  <defs
+     id="defs2433" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.53100044"
+     inkscape:cx="689.94488"
+     inkscape:cy="454.13473"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g6795"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     width="200mm"
+     inkscape:window-width="1277"
+     inkscape:window-height="943"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2436">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Background"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:type="star"
+       style="mix-blend-mode:normal;fill:#55a99d;fill-opacity:1;stroke:#081457;stroke-width:4;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3002"
+       sodipodi:sides="6"
+       sodipodi:cx="99.853607"
+       sodipodi:cy="99.518524"
+       sodipodi:r1="95.63076"
+       sodipodi:r2="82.591248"
+       sodipodi:arg1="0.52359878"
+       sodipodi:arg2="1.0471976"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="M 182.67227,147.3339 99.853607,195.14928 17.034939,147.3339 17.03494,51.703144 99.853608,3.887764 182.67228,51.703144 Z" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 27.615938,45.25733 v 108.07721 0"
+       id="path5008" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 37.25358,39.177987 v 120.010743 0"
+       id="path5008-9" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 46.891229,35.350251 v 129.467489 0"
+       id="path5008-1" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 56.52887,29.496068 v 140.950692 0"
+       id="path5008-7" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 66.166511,24.542532 v 151.082928 0"
+       id="path5008-2" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 75.804159,18.688349 v 163.016451 0"
+       id="path5008-3" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 85.441796,13.509649 v 173.148691 0"
+       id="path5008-6" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 95.079442,7.8806279 v 183.9564121 0"
+       id="path5008-5" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 104.71709,7.6554683 v 184.6319017 0"
+       id="path5008-58" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 114.35473,12.834167 v 174.274503 0"
+       id="path5008-14" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 123.99236,18.238028 v 163.241622 0"
+       id="path5008-71" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 133.63002,23.641888 v 152.433892 0"
+       id="path5008-38" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 143.26765,29.946391 v 140.725529 0"
+       id="path5008-4" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 152.9053,34.899931 v 129.692659 0"
+       id="path5008-8" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 162.54295,40.078629 v 119.785571 0"
+       id="path5008-0" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 172.18059,46.157973 v 107.401727 0"
+       id="path5008-46" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.112224,58.402265 H 182.60544 v -0.45032"
+       id="path5156" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 88.776279,9.9350961 H 109.36951 V 9.8790603"
+       id="path5156-8" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 73.628804,19.624444 H 125.83645 V 19.482383"
+       id="path5156-1" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 56.028962,29.318043 H 142.99118 V 29.081411"
+       id="path5156-5" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 39.605114,39.00868 H 159.09944 v -0.325152"
+       id="path5156-3" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 22.607548,48.692771 H 176.29508 v -0.418196"
+       id="path5156-54" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.274487,68.0957 H 181.7677 v -0.45032"
+       id="path5156-59" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.049326,77.789135 H 181.54254 v -0.45032"
+       id="path5156-549" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.274487,87.482561 H 181.7677 v -0.45032"
+       id="path5156-17" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.274487,97.175999 H 181.7677 v -0.45032"
+       id="path5156-55" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15.824165,106.86943 H 181.31738 v -0.45032"
+       id="path5156-4" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.499647,116.56287 H 181.99286 v -0.45032"
+       id="path5156-18" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.949969,126.25631 H 182.44319 v -0.45032"
+       id="path5156-83" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.499647,135.94975 H 181.99286 v -0.45032"
+       id="path5156-52" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.869476,145.67213 H 181.73272 v -0.44589"
+       id="path5156-2" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.76498,155.37467 h 135.54437 v -0.36881"
+       id="path5156-6" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 48.551663,165.06838 H 150.516 v -0.27744"
+       id="path5156-67" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 64.612673,174.76451 H 134.1202 v -0.18915"
+       id="path5156-84" />
+    <path
+       style="opacity:0.15;fill:none;stroke:#081457;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 81.156854,184.4136 h 36.907306 v -0.10043"
+       id="path5156-84-8" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Text"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <g
+       id="g1497-5-7-2-3"
+       transform="translate(-484.46887,-460.1542)"
+       style="fill:#ffffff">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:800;font-stretch:normal;font-size:9.87778px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Ultra-Bold';fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="584.06897"
+         y="602.44653"
+         id="text1997-9-9-0-8-1-9-45-2"><tspan
+           sodipodi:role="line"
+           x="584.06897"
+           y="602.44653"
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:9.87778px;font-family:Mulish;-inkscape-font-specification:'Mulish Heavy';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.264583"
+           id="tspan1646-1-6">COLLABORATIVE</tspan><tspan
+           sodipodi:role="line"
+           x="584.06897"
+           y="614.79376"
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:9.87778px;font-family:Mulish;-inkscape-font-specification:'Mulish Heavy';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.264583"
+           id="tspan2866">LESSON DEVELOPMENT</tspan><tspan
+           sodipodi:role="line"
+           x="584.06897"
+           y="627.14099"
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:9.87778px;font-family:Mulish;-inkscape-font-specification:'Mulish Heavy';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.264583"
+           id="tspan2868">TRAINING</tspan></text>
+    </g>
+    <g
+       id="g5508"
+       transform="matrix(0.26458333,0,0,0.26458333,42.703621,-12.507555)">
+      <path
+         id="path2"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z" />
+      <path
+         id="path4"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z" />
+      <path
+         id="path6"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z" />
+      <path
+         id="path8"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z" />
+      <path
+         id="path10"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 137.7288,208.9907 h 4.5675 v -20.1043 h 7.6822 v -4.1523 c -7.0246,0 -12.9416,0 -19.9314,0 v 4.1523 h 7.6817 z m 40.0811,0 v -24.1871 h -4.5328 v 10.2079 h -11.9035 v -10.2079 h -4.5675 v 24.1871 h 4.5675 v -9.7579 h 11.9035 v 9.7579 z m 26.3786,-4.4984 h -13.5988 v -5.4671 h 13.1145 v -4.2561 h -13.1145 v -5.6056 h 13.5988 v -4.4294 h -18.132 c 0,8.0856 0,16.1944 0,24.2566 h 18.132 z" />
+      <path
+         id="path12"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 148.9752,240.4494 c -1.5915,1.5914 -3.9795,2.4566 -6.0899,2.4566 -5.9865,0 -8.3046,-4.187 -8.3394,-8.2008 -0.0347,-4.0485 2.4914,-8.4084 8.3394,-8.4084 2.1104,0 4.2561,0.7267 5.8479,2.2838 l 3.0448,-2.9414 c -2.4914,-2.4566 -5.6056,-3.7023 -8.8927,-3.7023 -8.7546,0 -12.8722,6.4361 -12.8378,12.7683 0.0347,6.2975 3.8408,12.4916 12.8378,12.4916 3.4947,0 6.7127,-1.1418 9.2041,-3.5989 z" />
+      <path
+         id="path14"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 176.8417,246.6431 h 4.9828 L 170.959,222.3865 h -4.9827 l -10.8651,24.2566 h 4.9481 l 2.0761,-4.5676 h 12.6645 z m -3.8756,-8.8237 h -8.9969 l 4.4985,-10.3345 z" />
+      <path
+         id="path16"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 209.3792,246.3316 -7.336,-8.2698 c 4.6023,-0.9343 6.1251,-4.2909 6.1251,-7.6299 0,-4.2046 -3.0104,-8.0107 -8.7202,-8.0454 -3.8409,0.0347 -7.6818,0 -11.5227,0 v 24.2566 h 4.5676 v -8.097 h 4.3946 l 7.0589,8.097 h 5.4327 z m -9.9311,-19.689 c 2.8722,0 4.1527,1.9437 4.1527,3.8932 0,1.949 -1.2461,3.8927 -4.1527,3.8927 h -6.9551 v -7.7859 z" />
+      <path
+         id="path18"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 219.8405,226.7464 h 6.8513 c 5.8132,0 5.8479,8.5817 0,8.5817 h -6.8513 z m 6.8513,-4.3599 c -3.8066,-0.0344 -7.6127,0 -11.4188,0 v 24.2566 h 4.5675 v -7.128 h 6.8513 c 11.8688,0 11.834,-17.1286 0,-17.1286 z" />
+      <path
+         id="path20"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 260.7521,242.1446 h -13.5988 v -5.467 h 13.1145 v -4.2561 h -13.1145 v -5.6057 h 13.5988 v -4.4293 h -18.132 c 0,8.0855 0,16.1943 0,24.2566 h 18.132 z" />
+      <path
+         id="path22"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 284.9507,237.4271 -11.8688,-15.0406 h -3.7028 v 24.2566 h 4.5676 v -16.3554 l 12.7339,16.3554 v 0 h 2.8376 v -24.2566 h -4.5675 z" />
+      <path
+         id="path24"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 303.9932,246.6431 h 4.5675 v -20.1043 h 7.6822 v -4.1523 c -7.0246,0 -12.9416,0 -19.9315,0 v 4.1523 h 7.6818 z" />
+      <path
+         id="path26"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 344.5243,246.3316 -7.336,-8.2698 c 4.6022,-0.9343 6.125,-4.2909 6.125,-7.6299 0,-4.2046 -3.0104,-8.0107 -8.7202,-8.0454 -3.8409,0.0347 -7.6818,0 -11.5226,0 v 24.2566 h 4.5675 v -8.097 h 4.3946 l 7.0589,8.097 h 5.4328 z m -9.9312,-19.689 c 2.8723,0 4.1527,1.9437 4.1527,3.8932 0,1.949 -1.2461,3.8927 -4.1527,3.8927 h -6.9551 v -7.7859 z" />
+      <path
+         id="path28"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 354.9855,246.6431 v -24.2566 h -4.5332 v 24.2566 z" />
+      <path
+         id="path30"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 381.3641,242.1446 h -13.5988 v -5.467 h 13.1145 v -4.2561 h -13.1145 v -5.6057 h 13.5988 v -4.4293 h -18.132 c 0,8.0855 0,16.1943 0,24.2566 h 18.132 z" />
+      <path
+         id="path32"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 408.2269,226.4006 c -1.8338,-3.737 -5.7442,-4.8099 -9.516,-4.8099 -4.4637,0.0348 -9.377,2.0762 -9.377,7.0589 0,5.4328 4.5676,6.7475 9.5156,7.336 3.218,0.3458 5.6056,1.2801 5.6056,3.5638 0,2.63 -2.699,3.6333 -5.5709,3.6333 -2.9413,0 -5.7441,-1.1762 -6.8169,-3.8409 l -3.8062,1.9724 c 1.7995,4.4293 5.6056,5.9517 10.5536,5.9517 5.398,0 10.1736,-2.3185 10.1736,-7.7165 0,-5.7785 -4.7061,-7.0932 -9.7583,-7.7161 -2.9066,-0.3461 -5.398,-0.9342 -5.398,-3.0451 0,-1.7995 1.6266,-3.218 5.0175,-3.218 2.6299,0 4.9137,1.3147 5.7441,2.699 z" />
+      <path
+         id="path34"
+         style="fill:#fafafb;fill-rule:evenodd"
+         d="m 113.2072,176.3809 v 79.2385 h 2.5819 v -79.2385 z" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Book">
+    <g
+       id="g6795">
+      <path
+         style="fill:#081457;fill-opacity:1;stroke-width:0.264583"
+         d="m 143.36811,68.438661 c -37.23259,-8.494459 -42.94162,1.624604 -43.698932,3.513587 -0.753219,-1.888983 -6.103299,-13.800759 -43.33589,-5.3063 l -8.170636,8.478693 -0.07927,56.764219 43.32544,-2.26054 c 0,0 2.134374,2.17706 8.405138,2.2532 v 0.007 c 0,0 -0.08993,-0.005 -0.05394,-0.005 0.07237,9e-4 -0.01959,0.005 0.05394,0.005 v -0.0145 c 5.84142,-0.0807 8.40522,-2.24587 8.40522,-2.24587 l 43.3254,2.26054 0.0793,-59.062674 z"
+         id="path5543"
+         sodipodi:nodetypes="ccccccccccccccc" />
+      <path
+         style="fill:#e0d4c0;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 148.77123,128.71384 -6.38768,-5.45444 1.61393,-60.566995 4.77375,10.02146 z"
+         id="path6015"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#e0d4c0;fill-opacity:1;stroke:none;stroke-width:3.765;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 104.77913,126.15996 c -2.81429,3.01283 -5.767843,2.43394 -5.767843,2.43394 1.265173,-17.38709 42.634683,-8.46144 42.634683,-8.46144 l 7.12526,8.58138 z"
+         id="path6013"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#f3f1ea;fill-opacity:1;stroke:none;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 99.842452,74.984152 c 0,1.946901 0,53.064908 0,53.064908 C 89.675778,115.7508 58.046,123.62698 58.046,123.62698 V 62.824793 C 102.1017,52.62655 99.842452,72.40178 99.842452,74.984152 Z"
+         id="path6011" />
+      <path
+         style="fill:#e0d4c0;fill-opacity:1;stroke:none;stroke-width:3.465;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 94.631964,126.15996 -43.311265,2.36265 6.825463,-6.95664 c 0,0 40.943043,-10.35824 42.195458,7.02793 0,0 -2.924831,0.57981 -5.709656,-2.43394 z"
+         id="path6009"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#e0d4c0;fill-opacity:1;stroke:none;stroke-width:1.965;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 50.802147,72.521887 58.046,62.824793 58.146162,123.6193 51.320699,128.52261 Z"
+         id="path6007"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#f3f1ea;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+         d="M 143.99748,62.692405 V 123.2594 c 0,0 -33.56451,-9.96166 -44.353117,2.28992 V 74.805606 c 0,-2.573428 -2.397481,-22.271817 44.353117,-12.113201 z"
+         id="path6005"
+         sodipodi:nodetypes="cccsc" />
+      <path
+         style="fill:none;stroke:#e0d4c0;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 99.712291,71.05589 v 56.89563"
+         id="path6651" />
+    </g>
+    <g
+       id="g6855"
+       transform="matrix(0.01786487,0,0,0.0178428,63.931634,65.100627)"
+       style="stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none">
+      <g
+         id="layer1-6"
+         inkscape:label="egg-base"
+         style="display:inline;stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none"
+         transform="translate(-207.79611,0.49823653)">
+        <path
+           style="fill:#071159;fill-opacity:1;stroke:#071159;stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 1061.9825,40.289582 C 1023.4982,40.211612 985.83801,51.351638 950.59461,65.967844 869.28731,101.02698 801.64978,160.58203 743.80278,225.94878 647.99525,335.22611 577.18301,464.25395 525.94635,599.10239 c -43.87679,116.6016 -72.94254,238.9248 -82.31966,363.00667 -2.20187,47.42634 -1.60922,95.11084 -0.87468,142.63604 2.56928,59.2135 11.31913,118.4761 26.45036,175.9728 21.49686,81.6742 58.05257,160.6225 114.01035,225.1017 54.27653,63.7148 125.3379,112.1846 203.66905,142.5999 84.92589,33.284 176.55911,48.37 267.58603,51.0692 49.3334,0.9014 98.6866,0.6785 147.3743,-7.2414 97.9034,-14.3361 192.9743,-51.1042 272.1839,-110.1568 65.7147,-48.0531 119.6891,-110.8038 159.2761,-181.2985 43.1845,-76.3843 70.4416,-161.3875 79.8268,-248.2343 2.8075,-45.396 1.404,-90.9831 1.5389,-136.4704 0.3081,-43.28327 -4.2154,-86.2539 -10.6712,-129.02188 C 1679.8813,723.87077 1627.4883,564.41119 1547.6855,419.35028 1493.371,321.58965 1426.1479,229.48882 1340.8583,155.6213 1281.5133,104.19417 1211.2681,62.301261 1133.4258,45.772748 c -23.3486,-5.40087 -47.556,-5.290159 -71.4433,-5.483166 z m 9.3925,12.803684 c 71.3825,-0.431628 139.9392,27.424345 198.6133,65.888514 83.344,54.84774 150.5729,130.45145 206.6228,211.67243 84.5382,123.91561 144.5445,263.2842 182.7604,407.55013 27.8019,105.99548 43.2442,215.29669 44.2903,324.81416 1.2254,120.9657 -28.3567,243.2183 -91.71,347.3321 -57.8984,96.0371 -145.3984,174.6053 -248.5424,221.0942 -88.7922,40.3108 -187.379,57.3054 -284.8057,55.1866 -104.11103,-1.0812 -209.58004,-16.8101 -305.36398,-58.4756 -44.20076,-19.5811 -86.52098,-44.1637 -123.27136,-75.4535 -29.37019,-26.2931 -57.99992,-53.8851 -80.48426,-86.3093 -54.7437,-75.367 -85.85693,-165.1187 -101.00749,-256.0243 -8.29357,-48.7563 -12.82467,-98.1309 -12.77306,-147.5831 -0.52378,-44.5993 -0.36975,-89.3248 5.23446,-133.65505 19.72134,-184.7634 79.96075,-364.90821 173.38035,-526.11887 54.51794,-92.93323 120.61493,-180.66362 203.91115,-250.48954 52.85781,-43.69759 113.8876,-81.024021 182.32519,-94.498454 16.7343,-3.208088 33.7721,-4.859273 50.8203,-4.93042 z"
+           id="path9034"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="layer5"
+         inkscape:label="egg-outline"
+         style="display:none;stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none"
+         transform="translate(-207.79611,4.4982208)" />
+      <g
+         id="layer2-9"
+         inkscape:label="egg-highlight"
+         style="display:none;stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none"
+         transform="translate(-207.79611,0.49823653)">
+        <path
+           style="fill:#071159;fill-opacity:1;stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none"
+           d="m 403.39372,508.89061 c -25.4959,-8.459 -42.2603,-30.2114 -47.7999,-62.0221 -2.0064,-11.5216 -0.9231,-42.0063 1.9484,-54.8284 10.1023,-45.1099 36.2823,-87.2441 70.1213,-112.8537 17.0374,-12.8941 45.2998,-22.5097 60.4854,-20.5787 20.596,2.6189 34.7268,18.4911 40.1011,45.0429 2.689,13.2852 2.7007,41.1014 0.025,59.5517 -4.1723,28.7703 -18.5319,81.178 -27.2448,99.4343 -8.2383,17.2618 -20.5117,30.3261 -35.6037,37.898 -18.1791,9.1207 -47.7301,13.1013 -62.0329,8.356 z"
+           id="path9034-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csscccscccc" />
+      </g>
+      <g
+         id="layer3-0"
+         inkscape:label="egg-shadow"
+         style="display:none;stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none"
+         transform="translate(-207.79611,0.49823653)">
+        <path
+           style="opacity:0.655;fill:#000b45;fill-opacity:1;stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none"
+           d="m 1083.5271,1569.3977 c -722.3514,110.1794 -361.1757,55.0897 0,0 z m -132.76315,75.0212 c -633.84263,60.1652 -316.92132,30.0826 0,0 z m -338.4339,50.9286 c -54.1048,-2.9058 -107.7278,-11.3165 -161.9826,-25.4068 -13.8063,-3.5856 -21.6566,-6.309 -23.6891,-8.2185 -4.1641,-3.912 -6.2547,-11.3356 -4.4905,-15.9457 2.6883,-7.0247 4.0003,-7.2402 54.1622,-8.8944 48.8839,-1.6122 75.9691,-3.6568 109.3333,-8.2538 68.9427,-9.4989 135.0773,-29.3828 194.6667,-58.528 95.4565,-46.6878 180.6346,-123.4048 243.75145,-219.538 48.7218,-74.2082 84.5476,-162.3571 97.483,-239.8556 29.6243,-177.48377 16.0037,-366.13817 -40.7199,-563.99987 -9.3012,-32.4444 -28.6015,-91.0166 -34.6085,-105.0297 -5.5464,-12.9384 -8.049,-25.0068 -6.4137,-30.9294 1.6076,-5.8223 6.9212,-10.0409 12.647,-10.0409 4.0334,0 5.0492,0.8975 10.9404,9.6666 32.6043,48.5319 69.9714,133.5362 103.4465,235.3244 54.1096,164.5318 78.1164,316.78428 72.9487,462.64447 -0.8255,23.3004 -2.3898,50.7357 -3.4762,60.9673 -13.1083,123.452 -59.4523,236.6265 -134.8092,329.2111 -16.1778,19.8763 -50.8904,54.9056 -70.2887,70.9302 -86.38455,71.3602 -197.42575,114.17 -322.90085,124.4878 -24.2247,1.9922 -72.0669,2.6942 -96,1.4088 z"
+           id="path9034-3"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccsscccsscssssccc" />
+      </g>
+      <g
+         id="layer4"
+         inkscape:label="logo"
+         transform="translate(-207.79611,0.49823653)"
+         style="display:inline;stroke-width:67.2125;stroke-miterlimit:4;stroke-dasharray:none">
+        <g
+           style="fill:#071159;fill-opacity:1;stroke-width:6.52303;stroke-miterlimit:4;stroke-dasharray:none"
+           id="g9091"
+           transform="matrix(10.303871,0,0,10.303871,445.38654,-1241.3075)">
+          <path
+             d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
+             style="fill:#071159;fill-opacity:1;fill-rule:evenodd;stroke-width:6.52303;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path2-1"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
+             style="fill:#071159;fill-opacity:1;fill-rule:evenodd;stroke-width:6.52303;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path4-6"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
+             style="fill:#071159;fill-opacity:1;fill-rule:evenodd;stroke-width:6.52303;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path6-4"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
+             style="fill:#071159;fill-opacity:1;fill-rule:evenodd;stroke-width:6.52303;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path8-4"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+    <circle
+       id="path6887"
+       style="fill:#000000;stroke:#000000;stroke-width:0.264583"
+       cx="63.180996"
+       cy="105.30165"
+       r="0.013204564" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6897"
+       d="m 63.818134,114.15145 c 0.142095,-0.19523 0.282559,-0.39214 0.441738,-0.57414 0.03333,-0.0381 0.06397,-0.0797 0.103881,-0.11082 0.03355,-0.0262 0.07557,-0.0392 0.113355,-0.0587 -0.238048,0.1504 -0.5012,0.26697 -0.714145,0.4512 -0.03987,0.0345 0.10517,0.0148 0.154731,0.0328 0.235464,0.0855 0.481444,0.28506 0.693881,0.42135 0.213246,0.1438 0.438504,0.27717 0.706972,0.22392 0.05867,-0.0116 0.11412,-0.0359 0.17118,-0.0538 0.430313,-0.24757 0.938696,-0.45605 1.278255,-0.84369 0.0985,-0.11244 0.177628,-0.24335 0.256923,-0.36948 0.05409,-0.0723 0.08908,-0.15963 0.147595,-0.22895 0.156443,-0.18534 1.185535,-0.73013 -0.602726,0.32549 0.26714,-0.15605 0.557697,-0.11468 0.847916,-0.0582 0.245959,0.0568 0.486979,0.16088 0.742585,0.16907 0.108836,0.003 0.152805,-0.0107 0.255881,-0.0308 0.130297,-0.0318 0.249708,-0.0926 0.379957,-0.12401 0.224775,-0.0533 0.454512,0.0563 0.664009,0.12487 0.266613,0.0809 0.52083,0.19538 0.780561,0.29435 0.152953,0.0583 0.283977,0.11357 0.452025,0.10207 0.07137,-0.005 0.138657,-0.0353 0.207989,-0.0529 0.533945,-0.27906 0.949018,-0.42791 1.232251,-0.90166 0.07505,-0.12553 0.131252,-0.26489 0.193818,-0.39687 0.06553,-0.0859 0.08675,-0.12844 0.177173,-0.18999 0.03625,-0.0247 0.153871,-0.084 0.11661,-0.0609 -0.232077,0.14393 -0.476517,0.26841 -0.701299,0.42348 -0.03917,0.027 0.09145,-0.0272 0.13838,-0.0352 0.04426,-0.007 0.08948,-0.007 0.134228,-0.0108 0.222189,0.007 0.421008,0.1045 0.621929,0.188 0.220134,0.0915 0.187548,0.0763 0.415235,0.15444 0.51177,0.13271 1.013344,-0.0144 1.48867,-0.20431 0.115964,-0.0276 0.365202,-0.21722 0.485952,-0.18722 0.03173,0.008 0.05964,0.0268 0.08946,0.0402 0.227523,0.12836 0.35641,0.39124 0.569034,0.53401 0.175681,0.11795 0.236818,0.10163 0.443487,0.13033 0.253285,8e-4 0.489286,-0.072 0.707368,-0.19897 0.749967,-0.43677 0.822011,-0.44264 1.279544,-0.84486 0.03721,-0.0339 0.127392,-0.11949 0.174667,-0.15067 0.02421,-0.016 0.102301,-0.0545 0.07741,-0.0396 -0.253161,0.15108 -0.512632,0.29169 -0.762349,0.44839 -0.02405,0.0151 0.05417,-0.0185 0.08239,-0.0217 0.04529,-0.005 0.09114,-0.002 0.136716,-0.003 0.564872,0.0537 1.120383,0.18749 1.654622,0.3764 0.143293,0.053 0.284557,0.11134 0.427387,0.16551 0.04959,0.0188 0.116858,0.0486 0.172884,0.0445 0.03118,-0.002 0.06024,-0.0168 0.09037,-0.0252 0.587989,-0.30517 0.795869,-0.37383 1.067168,-0.78648 0.05177,-0.0787 0.09611,-0.15971 0.153834,-0.23418 0.277569,-0.18795 0.696994,-0.43439 -0.698947,0.40481 -0.01595,0.01 0.03436,-0.0166 0.05294,-0.0178 0.07783,-0.005 0.12905,0.0367 0.197887,0.0705 0.319693,0.19682 0.626689,0.41255 0.936165,0.62477 0.227417,0.15847 0.276508,0.21009 0.538908,0.0826 0.317455,-0.18463 0.634908,-0.36927 0.95236,-0.5539 0.04088,-0.0245 0.163915,-0.0973 0.122645,-0.0735 -0.238117,0.1375 -0.476689,0.27424 -0.713195,0.41449 -0.0342,0.0203 0.07025,-0.0373 0.106098,-0.0545 0.09494,-0.0455 0.0869,-0.0396 0.181131,-0.0696 0.254085,-0.0533 0.493181,0.0785 0.715505,0.18508 0.32199,0.1812 0.58661,0.1033 0.912074,-0.0203 0.283657,-0.0937 0.552053,-0.26093 0.853943,-0.28584 0.03394,0.01 0.0707,0.0131 0.101833,0.0299 0.141483,0.0763 0.247975,0.22148 0.355949,0.33581 0.07164,0.0759 0.121729,0.12606 0.193408,0.19885 0.02029,0.0203 0.105889,0.11147 0.138136,0.1219 0.266165,0.0861 0.761153,-0.21457 0.989192,-0.32716 0.195588,-0.0974 0.385517,-0.20571 0.580557,-0.30412 0.09676,-0.0488 0.294069,-0.15192 0.413562,-0.17009 0.132043,-0.0201 0.175361,0.0206 0.289248,0.0734 0.219649,0.14946 0.328475,0.40028 0.495864,0.59718 0.03579,0.0421 0.07785,0.0785 0.116771,0.1177 0.05515,0.0306 0.106098,0.0705 0.165452,0.0919 0.322011,0.11613 0.731885,0.004 1.050581,-0.0791 0.04972,-0.0124 0.185481,-0.052 0.245959,-0.0483 0.169479,0.0102 0.282496,0.22819 0.368276,0.34755 0.111445,0.12385 0.135721,0.36068 0.302689,0.43175 0.03566,0.0152 0.07544,0.0177 0.113165,0.0266 0.323389,-0.009 0.638924,-0.0801 0.963073,-0.077 0.197098,0.0148 0.392316,0.0498 0.558739,0.16017 0.07181,0.0514 0.104269,0.13273 0.151746,0.20313 0.02273,0.0154 0.04315,0.0349 0.06817,0.0462 0.145423,0.0656 0.374394,0.0615 0.532562,0.0619 0.158226,-0.003 0.20738,-0.0267 0.298696,0.11666 0.0536,0.10931 0.10559,0.21936 0.154371,0.3309 0.02064,0.0484 0.05598,0.09 0.09466,0.12502 0.05486,0.0234 0.110599,0.0455 0.165984,0.0691 0.03843,0.0204 0.07938,0.0286 0.12229,0.0319 0,0 0.803609,-0.58008 0.803609,-0.58008 v 0 c -0.0339,5.2e-4 -0.07068,0.007 -0.102873,-0.003 -0.04381,-0.0162 -0.104071,-0.0509 -0.140973,-0.063 -0.0057,-0.002 -0.01175,0.003 -0.01759,0.004 -0.02006,0.0134 -0.05544,-0.0552 -0.0646,-0.0712 -0.05736,-0.11102 -0.112008,-0.22337 -0.167166,-0.3355 -0.09832,-0.16535 -0.162928,-0.21922 -0.357672,-0.20272 -0.179916,0.017 -0.3601,-0.004 -0.53834,-0.0312 -0.05766,-0.0776 -0.09244,-0.1724 -0.173775,-0.23215 -0.192231,-0.13025 -0.372274,-0.1698 -0.603533,-0.1958 -0.320628,-0.0164 -0.632265,0.0404 -0.94991,0.0782 -0.0453,0.001 -0.103566,0.0133 -0.145156,-0.0176 -0.09642,-0.0717 -0.144684,-0.28549 -0.234553,-0.36805 -0.0964,-0.13493 -0.245954,-0.39106 -0.417602,-0.43442 -0.07506,-0.019 -0.200277,0.0237 -0.266301,0.0404 -0.281612,0.0821 -0.719992,0.21376 -1.008126,0.13694 -0.05239,-0.014 -0.09818,-0.046 -0.147275,-0.069 -0.03623,-0.0346 -0.07574,-0.0661 -0.10868,-0.10383 -0.179565,-0.2058 -0.290706,-0.47261 -0.520356,-0.63403 -0.112509,-0.0655 -0.196916,-0.13627 -0.337214,-0.13068 -0.127953,0.005 -0.338635,0.11603 -0.43991,0.167 -0.197098,0.0992 -0.387569,0.21122 -0.584779,0.3102 -0.215956,0.10898 -0.367393,0.19096 -0.588328,0.28233 -0.06396,0.0265 -0.12982,0.0481 -0.195445,0.0702 -0.03554,0.0119 -0.07048,0.0336 -0.107913,0.0316 -0.02871,-0.002 -0.124449,-0.0946 -0.135969,-0.10489 -0.108929,-0.10207 -0.212611,-0.2069 -0.314822,-0.31574 -0.06286,-0.0669 -0.177732,-0.19569 -0.254096,-0.2505 -0.0371,-0.0266 -0.08127,-0.0417 -0.121904,-0.0625 -0.03873,-0.003 -0.07747,-0.011 -0.116192,-0.008 -0.258736,0.0192 -0.522107,0.20636 -0.77067,0.27257 -0.305591,0.12921 -0.542044,0.24544 -0.859787,0.081 -0.233985,-0.11112 -0.479565,-0.25899 -0.746551,-0.24445 -0.410091,0.0708 -1.06961,0.54428 -1.257067,0.6527 -0.195395,0.11302 -1.088134,0.68521 0.589563,-0.33312 -0.05895,0.035 -0.160814,0.12257 -0.234876,0.12663 -0.09127,0.005 -0.172733,-0.088 -0.248174,-0.12071 -0.318368,-0.20162 -0.626777,-0.41851 -0.93817,-0.6306 -0.06081,-0.0398 -0.145592,-0.10354 -0.219972,-0.12697 -0.02252,-0.007 -0.04947,-0.0183 -0.07046,-0.007 -0.31374,0.16187 -0.744934,0.29007 -0.975405,0.59708 -0.07062,0.11227 -0.136602,0.22721 -0.221462,0.32983 -0.234733,0.28388 -0.40682,0.27233 0.662721,-0.31717 -0.03965,0.0402 -0.06236,0.0833 -0.126751,0.0798 -0.03141,-0.002 -0.06041,-0.0176 -0.09032,-0.0273 -0.149228,-0.0485 -0.295955,-0.10466 -0.444108,-0.15627 -0.539885,-0.18389 -1.09709,-0.30493 -1.657586,-0.40796 -0.01095,-0.001 -0.202832,-0.0305 -0.2365,-0.0135 -0.465786,0.23512 -0.815822,0.38389 -1.1561,0.71124 -0.357507,0.31254 -0.539549,0.36324 0.359069,-0.11594 0.07139,-0.0381 -0.138173,0.0849 -0.211415,0.11922 -0.219885,0.10319 -0.227309,0.0874 -0.461087,0.12258 -0.169587,-0.008 -0.256773,0.0102 -0.405643,-0.0814 -0.05755,-0.0354 -0.102407,-0.0884 -0.150517,-0.1358 -0.140615,-0.1387 -0.258188,-0.3008 -0.415385,-0.42264 -0.03547,-0.0261 -0.06747,-0.0578 -0.106413,-0.0784 -0.165959,-0.0877 -0.389247,0.10526 -0.535146,0.16074 -0.457832,0.20104 -0.944393,0.37216 -1.449591,0.26142 -0.194773,-0.0644 -0.21971,-0.0676 -0.406553,-0.14895 -0.208164,-0.0906 -0.409538,-0.20218 -0.63908,-0.23011 -0.533649,-0.003 -0.625076,0.18865 -1.260568,0.54768 -0.122311,0.0691 -0.204684,0.18086 -0.271394,0.30098 -0.06068,0.12714 -0.116117,0.2611 -0.194524,0.3788 -0.204695,0.30725 -0.762463,0.60886 0.408541,-0.0712 -0.06242,0.0279 -0.120304,0.0699 -0.187259,0.0837 -0.239596,0.0495 -0.481592,-0.09 -0.69383,-0.17366 -0.229003,-0.0903 -0.299707,-0.11432 -0.528498,-0.19747 -0.0794,-0.0291 -0.158911,-0.0578 -0.238193,-0.0872 -0.131535,-0.0487 -0.282187,-0.1254 -0.427596,-0.10134 -0.13761,0.0261 -0.264602,0.0691 -0.391568,0.1291 -0.07264,0.0217 -0.166454,0.0539 -0.24231,0.0591 -0.255395,0.0175 -0.503717,-0.0902 -0.746133,-0.14943 -0.288827,-0.0736 -0.589225,-0.14427 -0.871644,-0.0112 -0.771969,0.44926 -0.872736,0.35664 -1.196215,0.90863 -0.07754,0.12086 -0.15638,0.24048 -0.256374,0.34459 -0.237826,0.24762 -0.887505,0.6141 0.37156,-0.11878 -0.05121,0.0233 -0.100063,0.0527 -0.153622,0.07 -0.271632,0.0875 -0.451678,-0.029 -0.676151,-0.16505 -0.234482,-0.14501 -0.456443,-0.32134 -0.703805,-0.44425 -0.05589,-0.0278 -0.114474,-0.0923 -0.173188,-0.0712 -0.340355,0.1227 -0.647716,0.32257 -0.971577,0.48386 -0.265975,0.21423 -0.434189,0.52382 -0.654507,0.7812 0,0 0.901816,-0.39112 0.901816,-0.39112 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6899"
+       d="m 63.806874,112.19246 c 0.145375,-0.29015 0.337121,-0.55324 0.543234,-0.80262 0.06653,-0.0684 0.113353,-0.12329 0.191244,-0.17839 0.03189,-0.0226 0.134752,-0.0791 0.101155,-0.0592 -1.214175,0.72005 -0.882002,0.45681 -0.517215,0.36689 0.240016,-0.0318 0.482049,0.005 0.722894,0.008 0.106738,-0.003 0.213368,-0.0215 0.306999,-0.0761 0.565586,-0.3298 0.779042,-0.38282 1.119023,-0.74687 0.03253,-0.0369 0.117856,-0.13697 0.159115,-0.17139 0.02215,-0.0185 0.09763,-0.0614 0.07271,-0.0469 -1.551189,0.90449 -0.958173,0.45895 -0.648581,0.42291 0.203829,0.004 0.40319,0.0514 0.600426,0.0988 0.350563,0.0982 0.698495,0.20622 1.052008,0.29361 0.446497,0.11257 0.93831,-0.0345 1.20597,-0.51418 0.02032,-0.01 0.01881,-0.14603 0.03074,-0.15273 0.0091,-0.005 0.03893,0.004 0.03006,0.009 -0.26739,0.16805 -0.543033,0.3226 -0.814551,0.4839 0.03851,-0.025 0.08723,-0.0266 0.126764,-0.0486 0.329653,-0.18358 0.654818,-0.37512 0.980755,-0.56521 0.0593,-0.0346 0.11661,-0.0725 0.174884,-0.10878 0.05764,-0.0359 0.231931,-0.14127 0.172853,-0.1078 -0.225954,0.12803 -0.449064,0.26101 -0.673598,0.39152 0.224457,-0.13209 0.316193,-0.0479 0.518441,0.0745 0.230425,0.13947 0.187444,0.11133 0.438134,0.23471 0.177083,0.0718 0.258,0.12432 0.451797,0.12824 0.1436,0.003 0.265046,-0.0364 0.386927,-0.10897 0.954868,-0.56826 0.718526,-0.3218 1.064559,-0.7169 0.06527,-0.0778 0.09519,-0.12139 0.173627,-0.18506 0.272479,-0.22117 1.186953,-0.7249 -0.188388,0.0761 0.09625,-0.0303 0.27283,-0.17973 0.3772,-0.17902 0.07656,5.3e-4 0.129363,0.0595 0.185595,0.10065 0.239125,0.21555 0.444688,0.46624 0.722482,0.63381 0.121883,0.0531 0.268742,0.0928 0.396187,0.0237 0.787498,-0.42754 0.810164,-0.38571 1.225486,-0.8385 0.119803,-0.13299 0.239609,-0.26555 0.348663,-0.40759 0.02482,-0.0323 0.04643,-0.0671 0.07285,-0.0981 0.01913,-0.0225 0.089,-0.0764 0.06337,-0.0618 -0.258839,0.14748 -0.510159,0.30777 -0.765239,0.46166 0.02948,-0.008 0.05808,-0.0204 0.08843,-0.0228 0.160417,-0.0127 0.398169,0.0663 0.556882,0.10691 0.178305,0.0555 0.360759,0.0886 0.546285,0.10633 0.205632,0.0251 0.406146,-0.004 0.605084,-0.0548 0.123724,-0.0387 0.244268,-0.0858 0.371171,-0.11317 0.08389,-0.0388 0.160342,-0.0679 0.253058,-0.0774 0.214018,0.0151 0.421264,-0.0743 0.632954,-0.0624 0.02445,0.0108 0.05057,0.0184 0.07336,0.0323 0.119007,0.0729 0.204187,0.17751 0.329221,0.25066 0.142449,0.0833 0.225563,0.11009 0.378349,0.17141 0.16428,0.0414 0.219768,0.0699 0.391456,0.0556 0.118698,-0.01 0.26792,-0.0564 0.371991,-0.114 0.828432,-0.45884 0.699974,-0.37605 1.120847,-0.66379 0.06382,-0.0459 0.139731,-0.10256 0.20788,-0.14397 0.02688,-0.0163 0.109935,-0.0611 0.08282,-0.0452 -1.631754,0.95833 -0.982395,0.42818 -0.67822,0.44001 0.191971,0.1 0.299906,0.30097 0.464222,0.43851 0.04092,0.0175 0.07922,0.0432 0.122743,0.0525 0.339514,0.0721 0.695383,-0.13353 0.988219,-0.27419 0.2316,-0.10081 0.43601,-0.27393 0.684001,-0.33487 0.253471,0.043 0.455681,0.24486 0.638998,0.4131 0.08797,0.0708 0.185314,0.22616 0.319936,0.20317 0.06855,-0.0117 0.132038,-0.0437 0.198057,-0.0656 0.526952,-0.25597 1.008525,-0.52827 1.581497,-0.6708 0.266231,-0.0403 0.378954,-0.057 0.564848,0.13775 0.09619,0.0892 0.139324,0.22857 0.247997,0.30608 0.03294,0.0235 0.07076,0.0393 0.106145,0.0589 0.05107,0.0128 0.10087,0.0326 0.153204,0.0382 0.347959,0.0374 0.707766,-0.0978 1.032984,-0.20357 0.09166,-0.009 0.200295,-0.0932 0.297278,-0.068 0.01923,0.005 0.0205,0.0342 0.02801,0.0526 0.08502,0.19502 0.226764,0.34751 0.406982,0.45649 0.25463,0.11449 0.535218,0.0822 0.804209,0.0524 0.202401,-0.0262 0.405284,-0.049 0.609513,-0.0489 0.260353,0.007 0.484039,0.13688 0.710203,0.25011 0.275934,0.16214 0.544578,0.0714 0.834368,-0.006 0.216125,-0.0381 0.526534,-0.25543 0.744141,-0.18028 0.122383,0.12541 0.151027,0.31148 0.200972,0.47423 0.07951,0.21507 0.236712,0.25144 0.448736,0.26102 0.252169,-0.01 0.468842,-0.14784 0.696283,-0.24169 0.243152,-0.10426 0.395171,-0.0429 0.593026,0.11623 0.146371,0.0824 0.235527,0.35344 0.373182,0.43074 0.03181,0.0179 0.06902,0.0237 0.103524,0.0355 0.182446,0.0148 0.362153,-0.0272 0.540855,-0.0577 0.152572,-0.0386 0.26062,0.0175 0.381493,0.10616 0.108886,0.10235 0.198609,0.2211 0.273026,0.35016 0.05172,0.078 0.110913,0.10533 0.202599,0.11206 0.118036,0.003 0.236117,0.002 0.354174,0.002 0.06723,-0.008 0.112914,0.005 0.163941,0.0477 0.02138,0.0302 0.02989,0.063 0.05164,0.0932 0,0 0.847836,-0.51452 0.847836,-0.51452 v 0 c -0.01,-0.0156 -0.03713,-0.0762 -0.05912,-0.10147 -0.05903,-0.0531 -0.120968,-0.11269 -0.20615,-0.10612 -0.117684,0.002 -0.235392,0.005 -0.353108,0.003 -0.06312,5e-5 -0.104336,0.0214 -0.14837,-0.0321 -0.08804,-0.13446 -0.186542,-0.26081 -0.298924,-0.37604 -0.124423,-0.10037 -0.252759,-0.20517 -0.423074,-0.17449 -0.175432,0.026 -0.347644,0.0721 -0.524875,0.0862 -0.02498,0.002 -0.05075,0.0108 -0.07494,0.004 -0.10522,-0.0278 -0.269341,-0.36162 -0.380458,-0.42241 -0.184047,-0.16503 -0.396211,-0.30343 -0.648711,-0.20555 -0.228192,0.0855 -0.435924,0.22397 -0.675891,0.27125 -0.170857,0.011 -0.308377,0.0208 -0.376179,-0.16014 -0.06186,-0.18726 -0.105908,-0.38858 -0.240451,-0.53961 -0.02671,-0.0174 -0.05037,-0.0408 -0.08013,-0.0522 -0.193466,-0.0745 -0.536318,0.14474 -0.72521,0.18631 -0.188507,0.0541 -0.417888,0.14909 -0.61922,0.11421 -0.04765,-0.008 -0.118152,-0.043 -0.160552,-0.0618 -0.237373,-0.11094 -0.466251,-0.25454 -0.732377,-0.28324 -0.207862,-0.0171 -0.415398,0.0103 -0.621551,0.0379 -0.253079,0.0339 -0.517938,0.0804 -0.765858,-0.004 -0.169875,-0.0864 -0.299463,-0.22334 -0.366731,-0.40418 -0.100631,-0.24133 -0.208819,-0.15836 -0.422545,-0.0962 -0.307787,0.10959 -0.667869,0.25131 -0.998616,0.24243 -0.04516,-0.001 -0.0892,-0.0144 -0.133803,-0.0216 -0.0287,-0.012 -0.05961,-0.0198 -0.08611,-0.0361 -0.111869,-0.0689 -0.148648,-0.21739 -0.245285,-0.30158 -0.210762,-0.22951 -0.32499,-0.25133 -0.642625,-0.20781 -0.07479,0.0168 -0.150574,0.0296 -0.224372,0.0503 -0.481161,0.13494 -0.913913,0.3921 -1.361107,0.60707 -0.05537,0.025 -0.110931,0.0495 -0.166113,0.0749 -0.02061,0.01 -0.03872,0.0272 -0.06128,0.0297 -0.05769,0.006 -0.175725,-0.13747 -0.219025,-0.1625 -0.209028,-0.18346 -0.419634,-0.37269 -0.678082,-0.48438 -0.02722,-8e-4 -0.05469,-0.006 -0.08166,-0.002 -0.208388,0.0288 -0.449609,0.24953 -0.643593,0.32457 -0.266452,0.13371 -0.619422,0.34431 -0.928656,0.32576 -0.03533,-0.002 -0.06843,-0.0181 -0.10264,-0.0271 -0.184399,-0.13683 -0.294201,-0.34465 -0.482089,-0.47751 -0.39855,-0.15766 -0.57512,0.20612 -1.044448,0.47091 -0.09759,0.0551 -0.183155,0.12934 -0.277183,0.18973 -0.32131,0.21081 -0.320855,0.20614 0.5315,-0.28709 0.05514,-0.0319 -0.110831,0.0635 -0.169547,0.0882 -0.12428,0.0523 -0.226685,0.0785 -0.362628,0.0698 -0.06339,-0.004 -0.124785,-0.0239 -0.187179,-0.0358 -0.1768,-0.0667 -0.347909,-0.13045 -0.497658,-0.24955 -0.191463,-0.15227 -0.0088,-0.0351 -0.186711,-0.17209 -0.02853,-0.022 -0.06042,-0.0392 -0.09063,-0.0588 -0.03305,-0.01 -0.06485,-0.0259 -0.09914,-0.0289 -0.159618,-0.014 -0.37516,0.10907 -0.546145,0.071 -0.09995,0.001 -0.18062,-0.009 -0.267131,0.0484 -0.09821,0.0609 -0.269597,0.061 -0.373764,0.1256 -0.187409,0.0664 -0.381846,0.10271 -0.581167,0.0826 -0.182801,-0.0113 -0.363951,-0.0347 -0.539589,-0.0892 -0.223414,-0.0621 -0.452168,-0.1189 -0.68263,-0.14361 -0.301609,0.17666 -0.608243,0.345 -0.904833,0.52996 -0.01024,0.006 -0.121788,0.15871 -0.123904,0.16144 -0.107477,0.13812 -0.22478,0.26807 -0.343736,0.3963 -0.04762,0.0482 -0.09327,0.0985 -0.142852,0.1447 -0.04323,0.0403 -0.188531,0.14019 -0.135305,0.11453 0.241438,-0.11638 0.470181,-0.25746 0.703919,-0.38862 0.03802,-0.0213 -0.0752,0.0457 -0.116679,0.0591 -0.105772,0.0343 -0.127349,0.0127 -0.2301,-0.0146 -0.284022,-0.14889 -0.488558,-0.39791 -0.715481,-0.6189 -0.04442,-0.0395 -0.156382,-0.14846 -0.220226,-0.17253 -0.114615,-0.0432 -0.315603,0.1249 -0.414983,0.16047 -0.262535,0.15151 -1.115986,0.58754 -1.460291,0.90233 -0.04272,0.0391 -0.130027,0.14285 -0.167367,0.1861 -0.295442,0.29897 -0.104947,0.0853 0.57731,-0.25953 0.05785,-0.0292 -0.105013,0.0778 -0.164235,0.10414 -0.216763,0.0965 -0.422235,0.0527 -0.629343,-0.044 -0.215051,-0.10515 -0.226806,-0.10204 -0.421151,-0.23009 -0.127423,-0.084 -0.275283,-0.23836 -0.446381,-0.21752 -0.04744,0.006 -0.08845,0.0363 -0.132675,0.0544 -0.323871,0.18755 -0.648621,0.3736 -0.971611,0.56267 -0.05828,0.0341 -0.114546,0.0716 -0.172138,0.10684 -0.0603,0.0369 -0.243308,0.14416 -0.181536,0.10975 0.230151,-0.1282 0.457375,-0.2616 0.68675,-0.39117 0.02426,-0.0137 -0.0453,0.0337 -0.07137,0.0435 -0.01445,0.005 -0.03087,7.9e-4 -0.04631,0.001 -1.221793,0.71214 -0.821243,0.16589 -0.88071,0.55609 -0.0059,0.0386 -0.02193,0.0751 -0.05092,0.10166 -0.287896,0.19494 -0.02593,0.0163 0.780627,-0.43417 0.01466,-0.008 -0.02724,0.0207 -0.04322,0.0259 -0.07581,0.0247 -0.157731,-0.0126 -0.232907,-0.0174 -0.358627,-0.0723 -0.711864,-0.1704 -1.059297,-0.28474 -0.197651,-0.0549 -0.393808,-0.11403 -0.599199,-0.13135 -0.512416,-0.0387 -0.9467,0.38524 -1.27458,0.74667 -0.308978,0.2987 -0.618768,0.40386 0.538798,-0.23848 0.02915,-0.0162 -0.05477,0.0383 -0.08397,0.0543 -0.09467,0.0522 -0.08934,0.042 -0.196598,0.0611 -0.244983,0.01 -0.488141,-0.0309 -0.733338,-0.0241 -0.554371,0.097 -1.072076,0.42064 -1.441744,0.83998 -0.204166,0.26133 -0.393369,0.53447 -0.549039,0.8279 0,0 0.895157,-0.405 0.895157,-0.405 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6901"
+       d="m 63.909706,104.85219 c 0.17838,-0.19802 0.34993,-0.42201 0.591545,-0.54532 -0.257254,0.15156 -0.520922,0.29273 -0.77176,0.45469 -0.01987,0.0128 0.04807,-0.008 0.07094,-0.002 0.03203,0.008 0.06116,0.0264 0.08887,0.0446 0.115242,0.0756 0.212368,0.18274 0.312018,0.27677 0.107037,0.0587 0.230685,0.27326 0.358809,0.28481 0.02931,0.003 0.05826,-0.008 0.08739,-0.0125 0.307057,-0.18442 0.621686,-0.35678 0.921168,-0.55325 0.0058,-0.004 0.185766,-0.22739 0.191198,-0.23414 0.09297,-0.11561 0.185791,-0.23118 0.280421,-0.34544 0.0796,-0.0827 0.112051,-0.12541 0.208116,-0.18951 0.035,-0.0233 0.146468,-0.0827 0.111012,-0.06 -0.237141,0.15142 -0.49452,0.27338 -0.716302,0.44652 -0.03591,0.028 0.09172,-0.002 0.136557,0.006 0.04755,0.009 0.09216,0.029 0.13824,0.0436 0.218807,0.0776 0.391316,0.23544 0.588888,0.34998 0.162843,0.0926 0.352272,0.15642 0.52864,0.052 0.32235,-0.19083 0.635958,-0.39606 0.953937,-0.59409 0.182499,-0.19795 0.347234,-0.41026 0.538178,-0.60038 0.336701,-0.16723 -0.02806,0.0123 -0.731594,0.43337 -0.01627,0.01 0.03469,-0.0156 0.05278,-0.0213 0.05177,-0.0164 0.105664,-0.0197 0.159348,-0.0236 0.104688,0.006 0.198435,0.0747 0.283829,0.13078 0.126559,0.10993 0.262515,0.20382 0.411777,0.27975 0.253783,0.10783 0.535921,-0.0276 0.77072,-0.12683 0.501494,-0.23974 1.009817,-0.48452 1.456783,-0.81753 0.08406,-0.0791 0.127799,-0.18044 0.134445,-0.29379 0.004,-0.0613 0.0011,-0.12263 -0.0016,-0.18389 0.0029,-0.10044 0.03172,-0.20017 0.0492,-0.29964 -0.0091,10e-4 0.06899,-0.0783 0.0689,-0.0782 -0.845778,0.50383 -1.096629,0.63499 -0.79752,0.47807 0.12225,-0.0366 0.262837,-0.0193 0.389993,-0.0184 0.120565,0.008 0.243533,-0.008 0.362738,0.0147 0.105307,0.0208 0.189709,0.074 0.264353,0.14902 0.146826,0.19416 0.211429,0.4319 0.346115,0.63349 0.147945,0.1963 0.354746,0.28499 0.596154,0.28544 0.153061,-0.02 0.277934,-0.11392 0.418534,-0.16913 0.168063,-0.0535 0.342513,-0.0407 0.510217,0.005 0.253738,0.0906 0.475832,0.18838 0.748744,0.19936 0.49099,-0.07 0.957392,-0.34819 1.308529,-0.69635 0.07241,-0.0718 0.137996,-0.15015 0.207944,-0.22434 0.104661,-0.0994 0.204584,-0.20398 0.319021,-0.29252 0.203642,-0.15754 1.130549,-0.6785 -0.541631,0.31227 0.245264,-0.0698 0.473782,0.0806 0.693682,0.17219 0.168992,0.0565 0.356542,0.14114 0.539649,0.10568 0.03773,-0.007 0.07334,-0.023 0.110004,-0.0345 0.65932,-0.2729 0.994534,-0.59522 1.464585,-1.02774 0.286004,-0.18986 0.756187,-0.46128 -0.63377,0.36432 -0.03248,0.0193 0.07456,-0.0314 0.152096,-0.0489 0.193363,-0.015 0.35601,0.16894 0.484542,0.29042 0.18302,0.16847 0.395917,0.30356 0.631806,0.38314 0.213569,0.0633 0.413232,0.0178 0.614731,-0.0604 0.147754,-0.0565 0.300077,-0.17867 0.462621,-0.12022 0.162925,0.11205 0.332891,0.21182 0.514657,0.28987 0.293177,0.10526 0.596069,0.024 0.88075,-0.0668 0.517067,-0.20772 1.020956,-0.47546 1.466331,-0.81082 0.307912,-0.20757 0.83633,-0.49596 -0.6205,0.34791 0.115165,-0.0679 0.259294,-0.0589 0.388974,-0.0619 0.113882,-0.005 0.228545,0.006 0.341429,-0.0115 0.214413,-0.0225 0.465132,0.16026 0.635299,0.27747 0.168143,0.10835 0.331478,0.23455 0.525312,0.2926 0.0254,0.001 0.05091,0.007 0.07617,0.004 0.06881,-0.008 0.153652,-0.0414 0.217393,-0.0631 0.114265,-0.0389 0.227472,-0.0738 0.344439,-0.10356 0.187963,-0.0282 0.401768,-0.0873 0.587428,-0.0128 0.03023,0.0121 0.0571,0.0314 0.08564,0.0471 0.147693,0.0952 0.221242,0.29277 0.390216,0.35859 0.03959,0.0154 0.08299,0.0183 0.124489,0.0274 0.291891,-0.004 0.572598,-0.0986 0.855564,-0.1617 0.123773,-0.0169 0.253278,-0.0664 0.380101,-0.0474 0.03982,0.006 0.07835,0.0186 0.117533,0.0279 0.259985,0.0762 0.501171,0.20181 0.74131,0.32484 0.141713,0.0779 0.240456,0.10011 0.399113,0.0578 0.253926,-0.1246 0.400365,-0.0941 0.672116,-0.0228 0.259627,0.0767 0.472117,0.2185 0.636103,0.43167 0.07424,0.064 0.09887,0.19063 0.192392,0.23387 0.02561,0.0118 0.05445,0.0148 0.08168,0.0222 0.04363,-0.008 0.08809,-0.0131 0.130895,-0.025 0.0524,-0.0146 0.271322,-0.0974 0.32063,-0.11544 0.133514,-0.0488 0.267612,-0.0938 0.403378,-0.13583 0.199046,-0.0706 0.282932,-0.0478 0.442122,0.0807 0.154913,0.14653 0.324358,0.26521 0.520057,0.34962 0.157443,0.0668 0.315494,0.0762 0.480292,0.0387 0.153022,-0.0392 0.305996,-0.0771 0.454195,-0.13219 0.397142,-0.18268 0.05218,-0.0209 0.984326,-0.56166 0.01979,-0.0115 0.07932,-0.0457 0.05952,-0.0342 -1.704607,0.98808 -1.017365,0.50718 -0.722397,0.43688 0.11311,-0.0139 0.245364,0.20278 0.309142,0.28154 0.08734,0.12759 0.180121,0.25566 0.242692,0.39792 0.04558,0.0898 0.100425,0.17781 0.172296,0.24895 0.05052,0.0523 0.117634,0.0667 0.186921,0.0742 0.03942,0.0138 0.08772,-0.008 0.123338,-0.003 0.01169,0.0103 0.0707,0.0595 0.06846,0.0419 0.0091,0.0291 0.0099,0.0555 0.02413,0.0858 0.02743,0.0562 0.07506,0.0978 0.101946,0.15421 0.03153,0.0452 0.07004,0.0865 0.121672,0.10776 0.03086,-0.002 0.07614,0.0256 0.114273,0.0525 0.03698,0.0343 0.08951,0.0458 0.124354,0.0779 0.02826,0.0186 0.04269,0.0459 0.0539,0.0768 0.02717,0.0404 0.063,0.0629 0.110604,0.0691 0.100647,0.002 0.201578,0.001 0.302127,-0.004 0.121733,-0.009 0.235419,-0.0534 0.350462,-0.0902 0.03668,-0.006 0.06702,-0.0281 0.102791,-0.0345 0.05036,8e-4 0.08673,-0.003 0.134371,-0.0242 0.371581,-0.17463 0.750837,-0.35619 1.062593,-0.62493 0.03759,-0.0488 0.0873,-0.0566 0.125807,-0.10599 0.06572,-0.0806 0.113477,-0.17498 0.160218,-0.26711 0.02159,-0.0443 0.04519,-0.0878 0.06381,-0.13353 -0.0013,-0.008 -0.0024,-0.016 -0.0037,-0.0241 0,0 -0.891317,0.43645 -0.891317,0.43645 v 0 c -0.0026,5.3e-4 -0.0052,10e-4 -0.0078,0.002 -0.0195,0.0413 -0.03877,0.0828 -0.06145,0.12254 -0.05077,0.085 -0.0919,0.17629 -0.174075,0.23739 -0.04931,0.0297 -0.08661,0.0654 -0.131109,0.101 -0.270483,0.19416 -0.705749,0.40381 0.722686,-0.40899 0.01577,-0.009 -0.02843,0.0229 -0.04449,0.0313 -0.01564,0.008 -0.03319,0.0121 -0.04979,0.0181 -0.04207,0.0231 -0.06248,0.0575 -0.106899,0.0519 -0.04389,-10e-4 -0.08012,-0.004 -0.121328,0.0176 -0.113768,0.0375 -0.225075,0.0854 -0.3425,0.1084 -0.09469,0.0184 -0.189595,0.0106 -0.285708,0.0119 -0.01878,0.001 -0.05695,-1e-5 -0.04982,0.0246 -0.01968,-0.0416 -0.04163,-0.0879 -0.07905,-0.11566 -0.06242,-0.0465 0.0648,0.0502 -0.03801,-0.04 -0.0231,-0.0203 -0.06714,-0.0182 -0.08983,-0.0408 -0.03857,-0.032 -0.09549,-0.0717 -0.136673,-0.0902 -0.03319,0.002 -0.0514,-0.002 -0.07605,-0.0323 -0.02776,-0.0533 -0.06683,-0.0964 -0.09744,-0.14755 -0.0084,-0.0429 -0.01447,-0.0861 -0.0432,-0.12124 -0.03831,-0.0495 -0.0453,-0.0126 -0.07975,-0.0587 -0.05638,-0.0493 -0.08294,-0.0445 -0.154358,-0.0396 -0.04888,0.001 -0.108074,0.01 -0.15004,-0.0174 -0.06934,-0.0548 -0.11484,-0.13532 -0.15481,-0.21281 -0.07115,-0.14719 -0.17058,-0.27967 -0.262734,-0.41394 -0.103704,-0.12967 -0.200742,-0.29633 -0.353655,-0.36985 -0.01318,1e-5 -0.08445,-0.001 -0.09376,0.004 -0.301355,0.16127 -0.596516,0.33386 -0.89413,0.50194 -0.01963,0.0111 -0.07713,0.0467 -0.05755,0.0355 0.258604,-0.14739 0.515914,-0.29704 0.774642,-0.44421 0.02522,-0.0143 -0.04939,0.0305 -0.07409,0.0457 -0.143597,0.0621 -0.29187,0.10531 -0.444458,0.13963 -0.151995,0.0468 -0.292306,0.0752 -0.447386,0.0147 -0.193337,-0.0699 -0.354685,-0.17917 -0.502352,-0.32248 -0.159358,-0.14464 -0.279532,-0.23638 -0.501687,-0.15917 -0.280244,0.0867 -0.557209,0.18376 -0.828288,0.29607 -0.01664,0.006 -0.03219,0.0173 -0.0499,0.0189 -0.05751,0.005 -0.135258,-0.16944 -0.181002,-0.20048 -0.181636,-0.22348 -0.402005,-0.38732 -0.680199,-0.47484 -0.159739,-0.0506 -0.387029,-0.13326 -0.557725,-0.0974 -0.04639,0.01 -0.09613,0.0392 -0.137441,0.0609 -0.152035,0.073 -0.200676,0.0785 -0.354872,0.007 -0.249822,-0.11553 -0.495046,-0.24248 -0.754811,-0.33478 -0.05433,-0.0196 -0.150271,-0.0591 -0.21294,-0.0661 -0.103097,-0.0116 -0.211619,0.0341 -0.312351,0.0447 -0.279286,0.0603 -0.552561,0.15006 -0.836245,0.18744 -0.03369,5.3e-4 -0.06792,0.008 -0.101068,0.002 -0.1583,-0.0288 -0.26153,-0.26716 -0.388903,-0.35275 -0.03265,-0.022 -0.0631,-0.0476 -0.09794,-0.0658 -0.191958,-0.1006 -0.416901,-0.0533 -0.620572,-0.0287 -0.20909,0.0414 -0.408424,0.1125 -0.606875,0.18806 -0.191026,-0.005 -0.353314,-0.16169 -0.512559,-0.24924 -0.202353,-0.14602 -0.424002,-0.29345 -0.668705,-0.3524 -0.03236,0.009 -0.06358,0.023 -0.09684,0.0272 -0.07727,0.01 -0.15821,-0.009 -0.235775,2.7e-4 -0.137679,0.004 -0.278366,5.3e-4 -0.413989,0.0219 -0.357264,0.20607 -0.72736,0.39634 -1.065008,0.63444 -0.267452,0.1831 -0.661125,0.38417 0.641524,-0.35879 0.03941,-0.0225 -0.07756,0.0471 -0.117255,0.0691 -0.156562,0.0866 -0.142854,0.0752 -0.314381,0.14708 -0.265432,0.0963 -0.542964,0.18951 -0.826106,0.11153 -0.18356,-0.0652 -0.356232,-0.15712 -0.507034,-0.28146 -0.02421,-0.016 -0.04627,-0.0357 -0.07259,-0.0479 -0.153659,-0.0711 -0.31319,0.0439 -0.448149,0.10357 -0.183361,0.082 -0.365992,0.15443 -0.570595,0.11041 -0.230415,-0.057 -0.43902,-0.17889 -0.612963,-0.3399 -0.150984,-0.14602 -0.312364,-0.31858 -0.522197,-0.37248 -0.462725,0.0364 -0.859885,0.35617 -1.211128,0.64631 -0.126664,0.11897 -0.251364,0.2426 -0.38558,0.35309 -0.27473,0.22616 -0.530285,0.32116 0.590701,-0.29989 -0.06752,0.0361 -0.109262,0.0668 -0.186134,0.077 -0.14241,0.0188 -0.288232,-0.0481 -0.421444,-0.0851 -0.238692,-0.0935 -0.470792,-0.24949 -0.735166,-0.23503 -0.630405,0.34863 -0.997498,0.47941 -1.438405,0.95726 -0.06352,0.0664 -0.143954,0.15404 -0.214347,0.21313 -0.03529,0.0296 -0.15222,0.10336 -0.111564,0.0817 0.243189,-0.12981 0.480121,-0.27101 0.72018,-0.40651 -0.0371,0.0183 -0.0725,0.0405 -0.111289,0.0548 -0.03844,0.0142 -0.07943,0.0202 -0.119142,0.0303 -0.0396,0.004 -0.07903,0.0127 -0.118795,0.0116 -0.212466,-0.006 -0.411007,-0.11867 -0.606645,-0.18762 -0.174921,-0.0628 -0.356854,-0.0854 -0.541647,-0.0567 -0.150545,0.0376 -0.273751,0.12255 -0.411874,0.18976 -0.03202,0.007 -0.06334,0.019 -0.09605,0.0208 -0.169481,0.009 -0.341577,-0.0918 -0.443788,-0.21843 -0.142325,-0.20223 -0.204915,-0.44663 -0.348837,-0.64848 -0.08048,-0.0926 -0.170395,-0.16865 -0.291256,-0.20107 -0.132464,-0.0371 -0.244978,-0.0296 -0.382209,-0.0278 -0.132485,-10e-4 -0.265446,5.3e-4 -0.397439,-0.0126 -0.37951,0.0497 -0.86279,0.2503 -0.942258,0.6383 -0.01773,0.10521 -0.04633,0.20988 -0.04253,0.31738 6.3e-5,0.0564 0.0037,0.11326 -0.0049,0.16932 -0.02323,0.0923 -0.08114,0.164 -0.159854,0.21748 -0.303408,0.20364 -0.132569,0.0866 0.679993,-0.38143 0.03312,-0.0191 -0.06721,0.0364 -0.10092,0.0544 -0.121259,0.0648 -0.245695,0.12256 -0.368179,0.18498 -0.210626,0.10142 -0.465161,0.24025 -0.70558,0.18291 -0.151344,-0.0632 -0.289031,-0.14701 -0.405503,-0.2643 -0.100073,-0.0714 -0.200895,-0.13826 -0.315833,-0.18472 -0.450747,5.2e-4 -0.859359,0.23114 -1.182425,0.57156 -0.177099,0.19399 -0.333868,0.4063 -0.526826,0.58547 0.23318,-0.12525 0.464045,-0.25491 0.69954,-0.37576 0.01005,-0.005 -0.08634,0.0901 -0.213585,0.0998 -0.09153,0.007 -0.175379,-0.0417 -0.253473,-0.0806 -0.20963,-0.10389 -0.383196,-0.27304 -0.605735,-0.35544 -0.03704,-0.0154 -0.249563,-0.11463 -0.300802,-0.0936 -0.489942,0.20081 -0.936559,0.38119 -1.273201,0.76877 -0.125063,0.15445 -0.243994,0.31769 -0.380865,0.46202 -0.25009,0.26371 -0.514866,0.32989 0.648295,-0.32232 -0.01482,0.0163 -0.05246,0.0757 -0.09076,0.0691 -0.08733,-0.0151 -0.211836,-0.20199 -0.296328,-0.23875 -0.133495,-0.12332 -0.262032,-0.28038 -0.422153,-0.37033 -0.03077,-0.0173 -0.06643,-0.0531 -0.09859,-0.0386 -0.317215,0.14348 -0.611937,0.33224 -0.917903,0.49837 -0.220179,0.1615 -0.394589,0.37171 -0.583669,0.56681 0,0 0.904746,-0.37476 0.904746,-0.37476 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6903"
+       d="m 64.178396,102.19988 c 0.03067,-0.0243 0.06085,-0.0492 0.092,-0.0729 0.07974,-0.0606 0.150016,-0.11113 0.235402,-0.16383 0.03851,-0.0238 0.156848,-0.0903 0.117743,-0.0676 -0.720201,0.41934 -0.984176,0.56579 -0.645377,0.37696 0.163142,-0.0908 0.236471,-0.13597 0.423741,-0.10137 0.220638,0.0633 0.427947,0.16597 0.634137,0.26548 0.101732,0.0512 0.16746,0.0942 0.278884,0.0466 0.29995,-0.17564 0.603949,-0.34453 0.899851,-0.52691 0.02764,-0.017 0.126261,-0.13998 0.141927,-0.15752 0.06956,-0.0779 0.143336,-0.14905 0.208997,-0.2304 0.248076,-0.26211 0.757987,-0.51291 -0.647131,0.33836 -0.01876,0.0114 0.04019,-0.0181 0.06134,-0.0239 0.02593,-0.007 0.05288,-0.0101 0.07933,-0.0151 0.228803,-0.0352 0.449355,-0.0133 0.670195,0.0503 0.198045,0.0614 0.387474,0.14569 0.577701,0.2273 0.08256,0.0329 0.143973,0.066 0.235371,0.0683 0.04253,0.001 0.08912,0.004 0.126595,-0.0163 0.328549,-0.17656 0.654807,-0.35968 0.963271,-0.56937 0.05023,-0.0342 0.227669,-0.35537 0.243962,-0.38346 0.201512,-0.31936 0.316114,-0.68471 0.499142,-1.01281 0.01466,-0.0202 0.02603,-0.0432 0.04396,-0.0606 0.03484,-0.0338 0.09428,-0.059 0.136406,-0.0799 -0.255643,0.14969 -0.513987,0.29487 -0.766929,0.44908 -0.02416,0.0147 0.05222,-0.0222 0.07946,-0.0299 0.03529,-0.01 0.07173,-0.0153 0.107601,-0.0229 0.28598,-0.025 0.573563,0.0217 0.854448,0.0732 0.15571,0.0201 0.292698,0.0859 0.4285,0.15925 0.144828,0.10127 0.311259,0.14536 0.482023,0.17918 0.150276,0.0232 0.302882,0.0311 0.45479,0.027 0.09096,-0.009 0.179007,-0.0348 0.268825,-0.0509 0.02201,0.004 0.04522,0.004 0.06607,0.012 0.160557,0.0627 0.301347,0.18927 0.43674,0.29121 0.220562,0.16605 0.134334,0.0991 0.34426,0.27004 0.233941,0.15289 0.548809,0.36305 0.833342,0.40225 0.04626,0.006 0.09337,0.002 0.14006,0.002 0.431188,-0.10605 0.842552,-0.43327 1.182923,-0.65112 0.03934,-0.0252 0.06635,-0.0658 0.100139,-0.098 0.07115,-0.0679 0.143796,-0.13422 0.215524,-0.20152 0.07086,-0.0609 0.138134,-0.12306 0.216734,-0.17423 0.03481,-0.0226 0.144687,-0.0817 0.108884,-0.0606 -1.299216,0.76429 -0.902325,0.48314 -0.584928,0.36707 0.06539,-0.0151 0.136631,-0.0438 0.205473,-0.0316 0.13217,0.0236 0.286716,0.11115 0.409458,0.16174 0.346586,0.13778 0.706438,0.22423 1.074114,0.11648 0.07085,-0.0208 0.137929,-0.0527 0.206893,-0.0791 0.460391,-0.23133 0.909124,-0.48837 1.327261,-0.78958 0.0453,-0.0326 0.08976,-0.0665 0.136427,-0.0972 0.04136,-0.0272 0.170109,-0.10123 0.127442,-0.0762 -0.236961,0.13924 -0.473548,0.27912 -0.710324,0.41868 0.177938,-0.085 0.372507,-0.12485 0.568989,-0.12598 0.13639,-0.004 0.199197,0.1095 0.293415,0.18599 0.02635,0.0214 0.05572,0.0388 0.08358,0.0581 0.280167,0.11719 0.590518,0.12808 0.890151,0.14274 0.147486,0.007 0.295066,0.0106 0.44269,0.0125 0.108384,-0.002 0.216733,-0.004 0.325141,-0.004 0.110162,-1e-4 0.220316,-2.6e-4 0.330467,0.002 0.453104,0.0359 0.763987,-0.40297 1.09619,-0.65224 0.380302,-0.221 -0.540557,0.31407 -0.704815,0.41169 -0.02048,0.0122 0.04264,-0.0214 0.0647,-0.0304 0.07007,-0.0286 0.141531,-0.0403 0.215924,-0.0508 0.203311,-0.0247 0.37326,0.0788 0.544406,0.17144 0.561158,0.25688 1.064691,-0.46605 1.307288,-0.897877 0.120502,-0.20822 0.163803,-0.4549 0.284276,-0.6619 0.171667,-0.2262 1.214221,-0.753007 -0.747143,0.42038 -0.0088,0.005 0.01786,-0.0125 0.02804,-0.0122 0.03249,0.001 0.04569,0.0584 0.0522,0.0723 0.05902,0.17985 0.06848,0.371047 0.07439,0.558897 -0.0076,0.0827 0.0021,0.14678 0.03964,0.21926 0.02148,0.0344 0.02193,0.072 0.02376,0.1112 -0.0071,0.10508 0.03935,0.19458 0.09408,0.28094 0.06827,0.0828 0.20229,0.19692 0.321207,0.13379 0.318106,-0.16888 0.623877,-0.36003 0.935815,-0.54005 0.118049,-0.077 0.1929,-0.21315 0.312161,-0.28776 0.01908,-0.0119 0.08196,-0.0368 0.06263,-0.0253 -0.262998,0.15708 -0.529519,0.30819 -0.794279,0.46229 0.01466,-7.9e-4 0.03034,-0.008 0.04399,-0.002 0.08999,0.0357 0.183576,0.27891 0.23323,0.36444 0.04808,0.0819 0.09543,0.16002 0.18089,0.2053 0.0177,0.004 0.03502,0.0107 0.05307,0.0108 0.03386,5e-5 0.113543,-0.0204 0.140925,-0.0359 0.554128,-0.31358 0.740106,-0.36947 1.084498,-0.68403 0.110765,-0.0865 0.216114,-0.17823 0.321456,-0.27128 0.07149,-0.0484 0.106717,-0.13108 0.164441,-0.19171 0.09131,-0.0959 -0.0226,0.0477 0.05917,-0.0598 0.05657,-0.10554 0.04759,-0.22623 0.05159,-0.34246 0.0117,-0.44491 0.12954,-0.29445 -0.862745,0.35519 -0.0181,0.0119 0.0084,0.0425 0.01204,0.0638 0.004,0.0233 0.0074,0.0466 0.01111,0.07 0.0073,0.1364 0.03931,0.25759 0.09705,0.38082 0.05852,0.13561 0.127212,0.26488 0.212656,0.38543 0.107972,0.16429 0.272945,0.20814 0.45665,0.23821 0.231487,0.0264 0.465167,0.0312 0.69777,0.0214 0.171079,-0.005 0.336372,-0.047 0.500935,-0.0895 0.112141,-0.0292 0.219925,-0.0722 0.331391,-0.10548 0.155009,-0.0232 0.279895,0.10799 0.384553,0.20646 0.05065,0.0548 0.108085,0.10125 0.1801,0.12235 0.197403,0.0231 0.39562,-0.003 0.589973,-0.0372 0.236484,-0.035 0.46886,-0.12319 0.709782,-0.11864 0.172164,0.0268 0.192394,0.1248 0.238566,0.27381 0.05472,0.16468 0.09253,0.33262 0.164114,0.49126 0.07402,0.12266 0.201951,0.12466 0.331253,0.12248 0.183081,-0.008 0.35637,-0.0651 0.528706,-0.12172 0.166084,-0.0573 0.339376,-0.0695 0.513331,-0.0587 0.19457,0.0138 0.335061,0.10691 0.454539,0.25474 0.135998,0.16936 0.340963,0.27032 0.562064,0.24308 0.05609,-0.007 0.109646,-0.0275 0.164468,-0.0412 0.483987,-0.22346 0.218734,-0.0947 1.128797,-0.63794 0.110795,-0.0661 0.228211,-0.15623 0.310613,-0.25623 0.03919,-0.0639 0.08635,-0.11328 0.148588,-0.15447 0.299754,-0.1783 -0.543344,0.29756 -0.803358,0.4654 -0.01429,0.009 0.03098,0.0148 0.0443,0.0254 0.02328,0.0185 0.04493,0.0392 0.06484,0.0613 0.04764,0.0529 0.105572,0.1379 0.146026,0.19461 0.101449,0.12486 0.183804,0.26891 0.307592,0.37374 0.03645,0.0286 0.07375,0.0534 0.120237,0.0596 0.0432,-3e-5 0.08632,-0.003 0.129484,-0.004 0.03892,-2.7e-4 0.07785,-5.3e-4 0.116777,-8e-4 0.0029,-0.002 0.04331,0.004 0.04428,5.3e-4 0.0016,-0.005 -0.006,-0.0117 -0.0021,-0.0152 0.0033,-0.003 0.0077,0.004 0.01156,0.006 0.01207,0.0123 0.01402,0.0347 0.01802,0.0505 0,0 0.868545,-0.47362 0.868545,-0.47362 v 0 c -0.0117,-0.0371 -0.02283,-0.0746 -0.04768,-0.10565 -0.03346,-0.0309 -0.04307,-0.0543 -0.09037,-0.046 -0.03961,-4e-5 -0.0792,10e-5 -0.118806,8e-4 -0.04259,-2.7e-4 -0.08515,-2.7e-4 -0.12764,0.003 -0.03488,0.007 -0.05301,0.0198 -0.08759,-0.004 -0.129739,-0.0808 -0.206386,-0.226 -0.304499,-0.33878 -0.334189,-0.48376 -0.463311,-0.63482 -1.208145,0.11683 -0.05046,0.0507 -0.08804,0.11175 -0.138062,0.16294 -0.06124,0.054 -0.124799,0.10436 -0.191678,0.15138 -0.0369,0.026 -0.151717,0.0973 -0.112122,0.0757 0.08998,-0.0491 1.059815,-0.60178 0.536421,-0.30359 -0.0492,0.0197 -0.09646,0.0452 -0.1476,0.0591 -0.192506,0.0523 -0.380979,-0.0187 -0.50395,-0.16995 -0.131058,-0.1669 -0.280101,-0.29137 -0.497382,-0.32209 -0.179088,-0.0182 -0.35874,-0.0244 -0.533945,0.0267 -0.170503,0.0517 -0.335605,0.12683 -0.51544,0.14088 -0.07806,0.01 -0.201562,0.0364 -0.262416,-0.0276 -0.07694,-0.15044 -0.112176,-0.31423 -0.16306,-0.47448 -0.05597,-0.1905 -0.09749,-0.30595 -0.298599,-0.37288 -0.249875,-0.0404 -0.492053,0.0666 -0.737073,0.10482 -0.184333,0.0369 -0.364556,0.0619 -0.552802,0.0492 -0.0632,0.005 -0.107955,-0.0223 -0.151913,-0.0697 -0.130657,-0.11625 -0.268386,-0.24701 -0.442854,-0.28675 -0.111385,0.0283 -0.223338,0.0594 -0.327264,0.1037 -0.164753,0.0444 -0.327511,0.1029 -0.499395,0.11212 -0.227322,0.0197 -0.456436,0.009 -0.68384,-0.007 -0.158699,-0.0188 -0.312748,-0.0308 -0.407924,-0.17538 -0.08288,-0.11451 -0.148153,-0.23773 -0.20457,-0.367297 -0.04906,-0.11584 -0.07018,-0.23346 -0.08342,-0.35848 -0.0036,-0.0237 -0.0073,-0.0473 -0.01077,-0.071 -0.0033,-0.0227 0.01188,-0.0764 -0.0095,-0.0681 -0.973976,0.37815 -0.874575,0.11033 -0.885222,0.551337 -0.0058,0.10209 -0.007,0.20907 -0.08463,0.2852 -0.07682,0.0772 -0.133792,0.17412 -0.225613,0.23702 -0.10531,0.0893 -0.207833,0.18167 -0.314365,0.26956 -0.02617,0.0224 -0.05161,0.0457 -0.0785,0.0672 -0.02897,0.0232 -0.121689,0.0846 -0.08899,0.067 1.365049,-0.73395 0.909865,-0.50493 0.610862,-0.352 -0.07687,0.008 -0.109601,-0.089 -0.149998,-0.13798 -0.08427,-0.1368 -0.142957,-0.32296 -0.268697,-0.42858 -0.02051,-0.0172 -0.04772,-0.0243 -0.07158,-0.0365 -0.302794,0.16171 -0.60747,0.31996 -0.908386,0.48515 -0.128878,0.0707 -0.226166,0.25154 -0.365651,0.31447 0.24842,-0.13857 0.495448,-0.27967 0.745265,-0.41571 0.02482,-0.0135 -0.04363,0.0376 -0.06994,0.048 -0.06405,0.0252 -0.133562,-0.035 -0.172443,-0.0764 -0.0482,-0.0769 -0.07386,-0.14946 -0.06673,-0.2415 -0.0056,-0.0512 -0.01495,-0.10105 -0.04222,-0.145717 -0.02884,-0.0565 -0.02167,-0.11615 -0.02693,-0.17937 -0.01672,-0.19838 -0.02945,-0.40046 -0.09378,-0.59024 -0.03052,-0.0669 -0.03948,-0.10855 -0.09708,-0.1562 -0.01585,-0.0131 -0.03726,-0.0361 -0.0556,-0.0268 -0.56093,0.28519 -0.75565,0.2328 -0.929148,0.59095 -0.08838,0.21693 -0.155916,0.443217 -0.271407,0.648457 -0.06817,0.11308 -0.101142,0.17632 -0.183883,0.27964 -0.02839,0.0354 -0.133313,0.11948 -0.09203,0.1005 0.268301,-0.12331 0.520779,-0.27847 0.781375,-0.41733 0.01596,-0.008 -0.02938,0.0256 -0.04745,0.0263 -0.02259,7.9e-4 -0.0427,-0.0149 -0.06406,-0.0224 -0.187396,-0.0867 -0.36015,-0.2171 -0.57587,-0.21782 -0.483971,0.0353 -0.892276,0.30659 -1.273406,0.62067 -0.06928,0.0609 -0.05228,0.045 -0.118578,0.10672 -0.01611,0.015 -0.06765,0.0553 -0.04811,0.0452 1.051563,-0.54523 1.124778,-0.4514 0.780421,-0.44688 -0.111747,0.002 -0.223499,0.002 -0.335257,0.002 -0.107039,5.2e-4 -0.214066,-0.002 -0.321093,-5.3e-4 -0.151627,0.005 -0.303432,0.006 -0.455117,0.003 -0.286142,-0.009 -0.578223,-0.0176 -0.85325,-0.10482 -0.02418,-0.0144 -0.0501,-0.0262 -0.07253,-0.0432 -0.09126,-0.0691 -0.15249,-0.18466 -0.260903,-0.232267 -0.02156,-0.009 -0.04637,-0.008 -0.06955,-0.0125 -0.204941,-0.023 -0.415579,0.0217 -0.607711,0.0919 -0.317429,0.17954 -0.636291,0.35657 -0.952288,0.53862 -0.07739,0.0446 -0.183902,0.12562 -0.25527,0.176 -0.05086,0.0359 -0.208555,0.13542 -0.153369,0.10659 0.200512,-0.10471 1.005652,-0.57187 0.472544,-0.26318 -0.155295,0.0711 -0.238231,0.12065 -0.40834,0.15229 -0.284829,0.053 -0.559229,-0.0312 -0.822976,-0.13127 -0.05549,-0.0241 -0.111699,-0.0465 -0.166457,-0.0722 -0.101539,-0.0476 -0.209532,-0.13164 -0.325178,-0.14279 -0.02647,-0.003 -0.124391,0.0153 -0.148521,0.0192 -0.531816,0.13696 -1.002086,0.47932 -1.413415,0.8358 -0.04564,0.0426 -0.170873,0.16 -0.217025,0.20095 -0.03482,0.0309 -0.147587,0.11197 -0.106161,0.0907 0.24915,-0.12771 0.486174,-0.2779 0.732155,-0.41161 0.03771,-0.0205 -0.06932,0.0511 -0.106926,0.0717 -0.03883,0.0214 -0.08101,0.0359 -0.121518,0.0539 -0.04175,0.007 -0.08291,0.0217 -0.125254,0.0213 -0.250735,-0.003 -0.615772,-0.22614 -0.818925,-0.3576 -0.169661,-0.13798 -0.342942,-0.27091 -0.514792,-0.40614 -0.06565,-0.0516 -0.18819,-0.15097 -0.265123,-0.19779 -0.02368,-0.0144 -0.05029,-0.0233 -0.07543,-0.035 -0.09615,-0.0249 -0.188563,0.0163 -0.282993,0.0375 -0.143367,0.0321 -0.295212,0.005 -0.440476,-0.002 -0.163248,-0.0239 -0.326869,-0.0511 -0.461954,-0.15318 -0.143021,-0.0807 -0.286287,-0.15834 -0.452417,-0.17998 -0.286586,-0.059 -0.581308,-0.0878 -0.873167,-0.100643 -0.463698,0.0417 -0.523806,0.201883 -1.114613,0.544453 -0.07333,0.0425 -0.121727,0.1145 -0.158332,0.18838 -0.149265,0.33584 -0.279649,0.68152 -0.477705,0.99355 -0.04656,0.0704 -0.08841,0.14407 -0.139676,0.21108 -0.03993,0.0522 -0.193961,0.17021 -0.133104,0.14542 0.248422,-0.10121 0.475001,-0.24952 0.709287,-0.38015 0.0332,-0.0185 -0.06819,0.0359 -0.105447,0.0435 -0.09439,0.0191 -0.133776,-0.0103 -0.220803,-0.0426 -0.193315,-0.0817 -0.379002,-0.18185 -0.58235,-0.23757 -0.236646,-0.0722 -0.439304,-0.11414 -0.688499,-0.0866 -0.461992,0.0275 -0.888585,0.31769 -1.181264,0.66914 -0.09168,0.10369 -0.183777,0.21365 -0.28793,0.30506 -0.192416,0.16886 -1.263079,0.73937 0.705291,-0.39081 -0.114501,0.0803 -0.07861,0.0966 -0.22766,0.0294 -0.215464,-0.0932 -0.428014,-0.19403 -0.646785,-0.27872 -0.212106,-0.066 -0.269137,-0.0648 -0.468741,0.0425 -0.500189,0.28586 -1.019064,0.5447 -1.471554,0.90424 0,0 0.911632,-0.36254 0.911632,-0.36254 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6905"
+       d="m 64.160868,117.20872 c 0.0287,-0.0259 0.05597,-0.0535 0.08609,-0.0777 0.03705,-0.0298 0.07587,-0.0574 0.11517,-0.0842 0.04041,-0.0275 0.166174,-0.10313 0.123817,-0.0787 -1.281226,0.7393 -0.797232,0.42827 -0.474093,0.31965 0.183739,-0.0545 0.252944,-0.0133 0.39538,0.0984 0.08664,0.0742 0.173392,0.14702 0.279553,0.19089 0.510172,0.14654 0.950865,-0.46623 1.236342,-0.83145 0.0944,-0.12245 0.186069,-0.24624 0.316865,-0.33259 0.03811,-0.0252 0.159208,-0.0895 0.120256,-0.0657 -0.723836,0.44307 -0.973166,0.49034 -0.554794,0.38532 0.347919,-0.0353 0.6618,0.12318 0.963681,0.27448 0.147344,0.0571 0.278905,0.1965 0.442743,0.20896 0.03261,0.002 0.06529,-0.004 0.09793,-0.006 0.518467,-0.15997 1.001135,-0.48859 1.363937,-0.89278 0.05634,-0.0474 0.09804,-0.10602 0.153578,-0.15403 0.04599,-0.0397 0.02756,-0.0271 0.07955,-0.0506 -0.264094,0.1545 -0.528191,0.30899 -0.792285,0.46348 0.259266,-0.0552 0.529231,-0.0447 0.792306,-0.027 0.190476,0.007 0.364702,0.077 0.54311,0.13439 0.146518,0.0524 0.243419,0.0586 0.395063,0.0138 2.001393,-1.16711 0.50451,-0.23703 1.107844,-0.6746 0.05708,-0.0414 0.115568,-0.0809 0.174845,-0.11904 0.06299,-0.0406 0.256884,-0.1543 0.191847,-0.1171 -0.896255,0.51257 -0.797999,0.45757 -0.47733,0.28626 0.190749,-0.0958 0.308478,-0.17426 0.52111,-0.11701 0.20075,0.0909 0.390245,0.20546 0.582446,0.31309 0.140026,0.0785 0.265179,0.18001 0.41647,0.23625 0.808681,0.0686 1.109991,-0.62822 1.281002,-1.20628 0.07823,-0.30572 0.114625,-0.61967 0.164943,-0.93072 0.0077,-0.054 0.01188,-0.11503 0.03412,-0.16647 0.132993,-0.30743 0.91503,-0.63478 -0.709708,0.35916 0.02347,-0.002 0.04811,-0.0147 0.07036,-0.007 0.240294,0.0837 0.536543,0.4656 0.689911,0.66742 0.09875,0.13862 0.186928,0.28325 0.207002,0.45419 0.0065,0.1019 6e-6,0.20398 -0.0021,0.30592 0.02524,0.14494 0.107087,0.27588 0.194863,0.39158 0.05785,0.0807 0.128201,0.15104 0.212516,0.20342 0.06037,0.0557 0.135003,0.0749 0.213786,0.0875 0.166192,0.0189 0.328697,-0.0232 0.482867,-0.0813 0.541478,-0.26662 1.954088,-1.15288 0.287329,-0.15757 -0.02273,0.0136 0.04816,-0.0223 0.07336,-0.0304 0.02907,-0.009 0.05931,-0.0146 0.08897,-0.0219 0.126203,-0.0164 0.251364,-0.0378 0.374882,-0.0685 0.04549,-0.003 -0.015,-0.0511 0.04621,-0.0122 0,0 0.836567,-0.53314 0.836567,-0.53314 v 0 c -0.02863,-0.0215 -0.06726,-0.0729 -0.09966,-0.0596 -0.121198,0.0435 -0.248084,0.076 -0.37683,0.0838 -0.450536,0.0573 -0.467093,0.19243 -1.080747,0.54231 -0.02209,0.0126 -0.08739,0.0521 -0.06531,0.0394 0.255194,-0.14572 0.509355,-0.29325 0.764657,-0.43879 0.02781,-0.0159 -0.05478,0.0332 -0.08217,0.0497 -0.138605,0.0681 -0.288454,0.12026 -0.444881,0.11629 -0.06392,-0.003 -0.135697,-1.3e-4 -0.184928,-0.0466 -0.07078,-0.0548 -0.156009,-0.0918 -0.202708,-0.17601 -0.07778,-0.0944 -0.150961,-0.2088 -0.158845,-0.3338 0.0028,-0.10708 0.0052,-0.2146 -0.0072,-0.32123 -0.03622,-0.18462 -0.134424,-0.33946 -0.248904,-0.48732 -0.206224,-0.25525 -0.437957,-0.54404 -0.712285,-0.72869 -0.03236,-0.0218 -0.06992,-0.0346 -0.104878,-0.0519 -0.622131,0.37191 -0.914286,0.3005 -0.971674,0.85169 -0.04033,0.30527 -0.07628,0.61283 -0.157393,0.91052 -0.05946,0.18363 -0.116824,0.37209 -0.231418,0.53101 -0.02805,0.0389 -0.140957,0.12622 -0.09758,0.10575 0.441778,-0.2085 1.051275,-0.60277 0.729369,-0.3954 -0.154138,-0.0354 -0.277492,-0.13565 -0.412723,-0.21328 -0.196205,-0.11063 -0.392507,-0.22099 -0.589656,-0.32978 -0.04781,-0.0195 -0.131262,-0.0574 -0.184547,-0.0639 -0.135355,-0.0163 -0.28013,0.0744 -0.395322,0.12588 -0.478795,0.25062 -0.268917,0.13796 -1.165209,0.66303 -0.131461,0.077 -0.245822,0.15835 -0.369856,0.24616 -0.05169,0.0366 -0.210656,0.1397 -0.15426,0.11089 0.241171,-0.1232 0.473377,-0.26321 0.710068,-0.39481 -0.150643,0.0728 -0.192863,0.0796 -0.352544,0.0348 -0.188267,-0.0524 -0.367808,-0.13326 -0.566161,-0.14421 -0.267433,-0.0215 -0.534045,-0.0258 -0.802169,-0.011 -0.674198,0.37102 -0.770752,0.32823 -1.12169,0.72121 -0.07675,0.0806 -0.155329,0.15574 -0.243105,0.22462 -0.03181,0.025 -0.133001,0.0915 -0.09732,0.0724 0.0893,-0.0476 1.073094,-0.60284 0.661096,-0.37036 -0.03316,0.01 -0.1113,0.0372 -0.150847,0.0312 -0.104963,-0.0158 -0.261427,-0.14571 -0.362569,-0.17978 -0.317117,-0.15258 -0.640893,-0.32162 -1.001202,-0.32415 -0.516626,0.0666 -0.148857,-2.7e-4 -1.123016,0.54893 -0.177948,0.10034 -0.295392,0.27175 -0.420455,0.427 -0.07313,0.0891 -0.124566,0.15401 -0.200988,0.23863 -0.02307,0.0256 -0.102145,0.0902 -0.07144,0.0746 0.272225,-0.13836 0.53375,-0.29683 0.800624,-0.44524 -0.03275,0.0388 -0.01249,0.0314 -0.05821,0.0282 -0.105134,-0.0237 -0.186637,-0.0872 -0.267536,-0.15674 -0.151339,-0.12173 -0.242011,-0.22139 -0.452543,-0.17108 -0.577247,0.13349 -1.086548,0.50893 -1.531654,0.89138 0,0 0.908298,-0.37623 0.908298,-0.37623 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6907"
+       d="m 64.383708,108.17315 c 0.06231,-0.19762 0.162298,-0.40255 0.318603,-0.5443 0.03411,-0.0309 0.07447,-0.0542 0.111702,-0.0813 -1.300621,0.77182 -0.788107,0.37247 -0.430131,0.36772 0.1339,-0.002 0.25532,0.0357 0.380019,0.0787 0.181522,0.0794 0.356311,0.20085 0.560533,0.21379 0.05263,0.003 0.105383,-0.004 0.158075,-0.007 0.185933,-0.0261 0.361243,-0.0922 0.522615,-0.18774 0.475772,-0.28151 0.859441,-0.43402 1.199412,-0.80535 0.06788,-0.0934 0.159883,-0.1811 0.195882,-0.29415 0.01601,-0.072 0.0062,-0.0375 0.02895,-0.10391 0.02914,-0.12289 0.06027,-0.24532 0.09165,-0.36778 0.0037,-0.0145 0.0029,-0.031 0.01122,-0.0434 0.0047,-0.007 0.03098,-0.0135 0.02373,-0.009 -0.271891,0.16476 -0.54924,0.3206 -0.818001,0.49042 -0.01029,0.007 0.02574,-0.002 0.03637,0.003 0.05509,0.031 0.160954,0.13262 0.19997,0.16788 0.230568,0.21939 0.416319,0.4825 0.659241,0.6886 0.120293,0.0686 0.236918,0.0805 0.362119,0.005 0.863791,-0.52094 0.848728,-0.40674 1.224815,-0.9897 0.127703,-0.14564 0.18533,-0.35508 0.324463,-0.49185 0.01643,-0.0161 0.03846,-0.0254 0.05769,-0.038 -0.253918,0.15904 -0.507839,0.31808 -0.761757,0.47711 0.03861,0.015 0.07939,0.0252 0.115819,0.0449 0.251219,0.13571 0.459703,0.36321 0.652613,0.56866 0.138864,0.14216 0.241954,0.31346 0.367017,0.46613 0.01553,0.0163 0.04716,0.0536 0.07014,0.0588 0.136993,0.0313 0.410768,-0.10989 0.536635,-0.16436 0.381728,-0.19727 1.091825,-0.49694 1.266775,-0.74407 0.0046,-0.009 0.0067,-0.0202 0.01376,-0.0276 0.02265,-0.0238 0.06252,-0.022 0.09033,-0.0395 0.04754,-0.0299 0.09293,-0.0634 0.13658,-0.0987 0.204613,-0.16578 0.206764,-0.18452 0.396547,-0.39064 0.304461,-0.35029 0.548928,-0.74706 0.846624,-1.10228 0.04703,-0.0492 0.06862,-0.11573 0.109408,-0.16902 0.01275,-0.0167 0.03005,-0.0293 0.04508,-0.0439 -0.273958,0.16118 -0.55961,0.30397 -0.821873,0.48356 -0.01802,0.0123 0.02894,0.033 0.04002,0.0518 0.02521,0.0428 0.04568,0.0883 0.06851,0.13238 0.152586,0.32745 0.3013,0.65662 0.452089,0.98493 0.08261,0.16324 0.07721,0.29207 0.267522,0.34891 0.03649,-0.003 0.07348,-0.002 0.109482,-0.009 0.347123,-0.0649 1.283118,-0.67674 1.292106,-0.6818 0.252868,-0.14232 -0.502224,0.29079 -0.753335,0.43619 0.0566,-0.0484 0.147376,-0.0579 0.199308,-0.11166 -0.0052,-0.0656 0.138187,0.12208 0.147135,0.13164 0.02455,0.0258 0.0547,0.0633 0.09013,0.0758 0.0241,0.008 0.05342,0.0221 0.07598,0.0101 0.877565,-0.46678 0.675058,-0.33596 1.064445,-0.67828 0.06243,-0.046 0.114052,-0.10756 0.177742,-0.15197 0.01357,-0.009 0.05787,-0.032 0.0436,-0.0236 -0.791451,0.46308 -1.081016,0.60741 -0.767668,0.45023 0.03138,-0.0292 0.153673,0.0261 0.179628,0.0127 0.905992,-0.46502 0.737296,-0.20113 0.948259,-0.56593 0.314031,-0.42969 0.402635,-0.3598 -0.623721,0.2487 0.01556,0.003 0.03378,8e-4 0.04664,0.01 0.05451,0.0396 0.198133,0.19993 0.233484,0.23979 0.108572,0.12244 0.214379,0.24704 0.324252,0.36839 0.0276,0.0281 0.213111,0.25694 0.267878,0.22508 0.300106,-0.1746 0.583329,-0.37672 0.874992,-0.56508 0.0936,-0.18149 0.179938,-0.37634 0.332444,-0.51676 0.347274,-0.148 -0.04298,0.0151 -0.710549,0.42829 -0.02183,0.0135 0.04853,-0.0173 0.07373,-0.0221 0.03266,-0.006 0.06593,-0.01 0.09915,-0.0109 0.08741,-0.004 0.138944,0.005 0.226232,0.0146 0.05431,0.0121 0.10948,0.0209 0.162941,0.0364 0.02027,0.006 0.377077,0.13242 0.383667,0.13471 0.17307,0.0603 0.34666,0.11622 0.52251,0.16768 0.137332,0.0412 0.276577,0.0739 0.417211,0.10106 0.01117,-0.001 0.02365,0.002 0.03348,-0.003 0.667642,-0.3658 1.624608,-0.93161 0.07717,-0.0337 -0.01598,0.009 0.03222,-0.0182 0.04904,-0.0259 0.03647,-0.0166 0.07424,-0.0303 0.110709,-0.0469 0.100341,-0.0529 0.208637,-0.0722 0.32018,-0.0828 0.06947,-0.006 0.139266,-0.008 0.208884,-0.005 0.800579,-0.45472 0.820486,-0.34176 1.044662,-0.90803 0.02297,-0.0406 0.0062,-0.0304 0.04468,-0.0381 -0.279263,0.15951 -0.561679,0.31363 -0.837787,0.47854 -0.0072,0.004 0.01677,0.003 0.02389,0.008 0.04297,0.0263 0.08084,0.0602 0.121465,0.09 0.130048,0.088 0.261073,0.17424 0.400236,0.24721 0.05236,0.0251 0.107743,0.0439 0.164623,0.0555 0.03824,0.005 0.07666,10e-4 0.11502,5.3e-4 0.04238,-8e-4 0.02146,-5.3e-4 0.06281,-8e-4 0,0 0.800126,-0.58198 0.800126,-0.58198 v 0 c -0.04144,2.1e-4 -0.02058,2.2e-4 -0.06253,-4e-5 -0.0369,1.7e-4 -0.07377,-0.002 -0.110482,0.003 -0.0494,0.008 -0.09928,-0.007 -0.146635,-0.0197 -0.140213,-0.0611 -0.268488,-0.14169 -0.394803,-0.22761 -0.05108,-0.0394 -0.07014,-0.052 -0.115271,-0.0938 -0.01537,-0.0142 -0.02564,-0.0528 -0.04471,-0.0441 -0.889688,0.40258 -0.780637,0.16192 -0.913932,0.53727 -0.197482,0.49984 -0.535207,0.55218 0.61994,-0.12429 -0.0052,0.0114 -0.0058,0.0261 -0.01545,0.034 -0.01701,0.0141 -0.149103,-0.0119 -0.171807,0.003 -0.115025,0.008 -0.234931,0.008 -0.341151,0.0583 -0.380749,0.15794 -0.628187,0.27333 -1.047096,0.57191 -0.255344,0.182 0.54593,-0.30864 0.819443,-0.46199 0.0084,-0.005 -0.01593,0.0106 -0.02392,0.016 -0.07503,0.0582 -0.324763,-0.0499 -0.410395,-0.0538 -0.177657,-0.0458 -0.352647,-0.0962 -0.526087,-0.1564 -0.787366,-0.27329 0.354494,0.11928 -0.381741,-0.14556 -0.05355,-0.0193 -0.108596,-0.0341 -0.162893,-0.0511 -0.567283,-0.0961 -0.858962,0.0267 -1.390444,0.53164 -0.127937,0.16493 -0.215283,0.3543 -0.326988,0.52986 0.264959,-0.14908 0.522431,-0.31234 0.794875,-0.44726 0.0173,-0.009 0.0029,0.0412 -0.0076,0.0574 -0.01675,0.026 -0.195557,-0.16486 -0.20015,-0.16801 -0.227867,-0.23292 -0.428339,-0.48958 -0.655489,-0.72275 -0.99309,0.57251 -0.682252,0.27595 -1.059416,0.74313 -0.29714,0.21853 -0.143033,0.10134 0.754325,-0.39855 0.01082,-0.006 -0.02384,0.008 -0.03625,0.008 -0.05003,-1e-5 -0.09926,-0.0266 -0.149291,-0.0278 -0.437436,-0.0617 -0.823471,0.40661 -1.15012,0.68248 -0.02627,0.0235 -0.05211,0.0476 -0.07885,0.0706 -0.02603,0.0224 -0.109831,0.0817 -0.07946,0.0656 0.26148,-0.1381 0.511664,-0.29708 0.774459,-0.43266 0.01714,-0.009 -0.01553,0.0372 -0.03078,0.049 -0.02764,0.0214 -0.06307,-0.0326 -0.0703,-0.0399 -0.06834,-0.0737 -0.123423,-0.15869 -0.201155,-0.22314 -0.07853,-0.0101 -0.153308,0.0798 -0.225132,0.0999 -0.306257,0.17615 -0.612981,0.35148 -0.91877,0.52844 -0.245785,0.14222 0.49268,-0.28254 0.738756,-0.42427 0.03742,-0.0215 -0.07479,0.0432 -0.112776,0.0637 -0.10074,0.0545 -0.203515,0.1007 -0.314153,0.13146 -0.01455,0.002 -0.06336,0.0152 -0.08224,0.004 -0.06507,-0.0382 -0.09246,-0.21085 -0.144335,-0.26126 -0.160713,-0.32349 -0.311251,-0.65217 -0.453663,-0.98405 -0.02201,-0.0497 -0.04137,-0.10063 -0.06602,-0.14905 -0.01881,-0.037 -0.02506,-0.12054 -0.06414,-0.10666 -0.802523,0.28486 -0.75978,0.24845 -1.047773,0.66048 -0.275511,0.35929 -0.511297,0.74934 -0.821103,1.08217 -0.205645,0.20474 -0.203332,0.2192 -0.42509,0.3812 -0.05321,0.0389 -0.166873,0.10078 -0.224735,0.15503 -0.0066,0.006 -0.0087,0.016 -0.01299,0.024 -0.0057,0.005 -0.01143,0.0101 -0.01714,0.0151 -0.27356,0.20539 -0.02785,0.0192 0.77419,-0.44193 0.01942,-0.0112 -0.03827,0.0233 -0.0576,0.0346 -0.102807,0.0601 -0.207749,0.11653 -0.314368,0.16959 -0.137755,0.0655 -0.28121,0.11147 -0.419767,0.17339 -0.02011,0.009 -0.03735,0.0233 -0.05618,0.0348 -0.0058,0.004 -0.01114,0.0117 -0.01767,0.01 -0.01101,-0.003 -0.01757,-0.0145 -0.02633,-0.0218 -0.138536,-0.14258 -0.242382,-0.31933 -0.38635,-0.458 -0.240728,-0.25418 -0.493644,-0.50238 -0.796999,-0.68179 -0.314595,0.15496 -0.633479,0.30152 -0.943787,0.4649 -0.0199,0.0105 -0.09254,0.12874 -0.09705,0.13602 -0.08376,0.13526 -0.16238,0.27379 -0.251889,0.40548 -0.0414,0.0602 -0.07967,0.12262 -0.12419,0.18052 -0.04572,0.0594 -0.217212,0.19501 -0.146156,0.17104 0.241483,-0.0815 0.449887,-0.23986 0.679289,-0.35087 0.01341,-0.007 -0.09793,0.0986 -0.209505,0.10064 -0.02899,5.3e-4 -0.0566,-0.0126 -0.08489,-0.019 -0.255646,-0.18707 -0.435351,-0.45709 -0.659921,-0.6779 -0.01625,-0.0161 -0.259337,-0.25678 -0.266885,-0.25329 -0.920412,0.4253 -0.811152,0.18021 -0.898909,0.57822 -0.02831,0.12119 -0.05907,0.24205 -0.09569,0.36099 -0.04363,0.13601 -0.131726,0.24684 -0.227918,0.35119 -0.29464,0.28445 -0.636177,0.41199 0.444598,-0.17032 0.05617,-0.0303 -0.108693,0.0671 -0.165391,0.0964 -0.05395,0.0278 -0.108924,0.0543 -0.1661,0.0748 -0.05253,0.0188 -0.107908,0.0283 -0.161862,0.0424 -0.04684,0.008 -0.09304,0.0222 -0.140536,0.0242 -0.199699,0.008 -0.377885,-0.11635 -0.549812,-0.19717 -0.705043,-0.27632 -0.930119,0.0148 -1.656276,0.45993 -0.203313,0.19032 -0.341749,0.41806 -0.417126,0.68746 0,0 0.886944,-0.42489 0.886944,-0.42489 z" />
+    <path
+       id="rect7155"
+       style="opacity:0.75;fill:#ffc700;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 111.21503,78.883358 c 2.67218,-0.372297 6.02377,-0.492477 7.92254,-0.420397 l 0.0123,9.570746 c -3.74968,-0.0704 -6.03792,0.16146 -7.93487,0.52917 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="rect7155-1"
+       style="opacity:0.75;fill:#ffc700;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 121.81892,82.685194 c 1.02445,-0.12178 7.11,0.428397 7.9159,0.682967 l 0.019,5.510436 c -1.9161,-0.29559 -5.867,-0.7089 -7.93487,-0.73582 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="rect7155-12"
+       style="opacity:0.75;fill:#ffc700;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 132.42094,81.352053 c 2.6969,0.29489 6.51755,1.242454 7.91058,1.554961 l 0.0243,7.900023 c -1.67645,-0.39209 -4.84924,-1.09669 -7.93488,-1.50638 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="rect7155-11"
+       style="opacity:0.75;fill:#0044d7;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 111.21699,74.921912 c 1.31343,-0.15505 5.16268,-0.572967 7.92058,-0.35724 v 3.898289 c -3.25804,-0.0847 -6.02202,0.16453 -7.92254,0.420397 l 0.002,-3.961446 z"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       id="rect7155-1-5"
+       style="opacity:0.75;fill:#0044d7;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 121.80917,80.356976 c 1.43573,-0.113947 5.42264,0.39731 7.94462,0.663497 l -0.019,2.347688 c -1.48418,-0.29667 -6.5299,-0.800967 -7.91589,-0.682967 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="rect7155-12-2"
+       style="opacity:0.75;fill:#0044d7;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 132.42094,76.050043 c 1.13252,0.11045 6.35918,1.126244 7.93487,1.576181 l -0.0243,5.28079 c -1.56213,-0.388547 -5.93089,-1.365441 -7.91057,-1.554961 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="rect7155-2"
+       style="opacity:0.75;fill:#ff4955;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902"
+       d="m 111.2027,70.020919 c 1.78125,-0.374357 6.86838,-0.632387 7.93487,-0.447237 v 4.99099 c -2.99801,-0.155827 -5.27795,0.0791 -7.92054,0.35724 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="rect7155-1-2"
+       style="opacity:0.75;fill:#ff4955;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902"
+       d="m 121.80523,77.166047 c 1.40735,0.0393 5.57928,0.381697 7.94856,0.725844 v 3.131872 c -1.7766,-0.200147 -6.7949,-0.799714 -7.94462,-0.666787 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="rect7155-12-4"
+       style="opacity:0.75;fill:#ff4955;fill-opacity:0.74902;stroke:none;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74902"
+       d="m 132.40927,73.441238 c 2.01968,0.1922 7.31607,1.336364 7.94654,1.529481 v 2.655505 c -1.92645,-0.502437 -6.18355,-1.354741 -7.93487,-1.576181 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#666666;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 109.60944,68.937818 v 19.806599 c 0,0 0.0579,0.005 0.0863,0 13.85697,-2.306607 31.42106,2.28387 31.42106,2.28387"
+       id="path7153"
+       sodipodi:nodetypes="ccsc" />
+    <path
+       style="fill:none;stroke:#666666;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 108.76906,70.058736 0.84038,-0.200088"
+       id="path7968" />
+    <path
+       style="fill:none;stroke:#666666;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 108.76906,73.835888 109.60944,73.6358"
+       id="path7968-4" />
+    <path
+       style="fill:none;stroke:#666666;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 108.76906,77.613039 0.84038,-0.200088"
+       id="path7968-7" />
+    <path
+       style="fill:none;stroke:#666666;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 108.76906,81.390191 0.84038,-0.200088"
+       id="path7968-40" />
+    <path
+       style="fill:none;stroke:#666666;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 108.76906,85.167343 0.84038,-0.200088"
+       id="path7968-75" />
+    <path
+       style="fill:none;stroke:#666666;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 108.76906,88.944497 0.84038,-0.20009"
+       id="path7968-0" />
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:1.41111px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Bold';fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none"
+       x="93.556137"
+       y="86.947815"
+       id="text8028"
+       transform="rotate(-9.1226819)"><tspan
+         sodipodi:role="line"
+         id="tspan8026"
+         x="93.556137"
+         y="86.947815"
+         style="font-size:1.41111px;fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none">100</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:1.41111px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Bold';fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none"
+       x="93.790619"
+       y="90.756729"
+       id="text8028-0"
+       transform="rotate(-9.1226819)"><tspan
+         sodipodi:role="line"
+         id="tspan8026-5"
+         x="93.790619"
+         y="90.756729"
+         style="font-size:1.41111px;fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none">80</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:1.41111px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Bold';fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none"
+       x="93.195686"
+       y="94.461647"
+       id="text8028-9"
+       transform="rotate(-9.1226819)"><tspan
+         sodipodi:role="line"
+         id="tspan8026-2"
+         x="93.195686"
+         y="94.461647"
+         style="font-size:1.41111px;fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none">60</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:1.41111px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Bold';fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none"
+       x="92.600838"
+       y="98.165947"
+       id="text8028-8"
+       transform="rotate(-9.1226819)"><tspan
+         sodipodi:role="line"
+         id="tspan8026-3"
+         x="92.600838"
+         y="98.165947"
+         style="font-size:1.41111px;fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none">40</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:1.41111px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Bold';fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none"
+       x="92.005135"
+       y="101.85854"
+       id="text8028-7"
+       transform="rotate(-9.1226819)"><tspan
+         sodipodi:role="line"
+         id="tspan8026-6"
+         x="92.005135"
+         y="101.85854"
+         style="font-size:1.41111px;fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none">20</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-weight:bold;font-size:1.41111px;line-height:1.25;font-family:Mulish;-inkscape-font-specification:'Mulish Bold';fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none"
+       x="92.261368"
+       y="105.54913"
+       id="text8028-2"
+       transform="rotate(-9.1226819)"><tspan
+         sodipodi:role="line"
+         id="tspan8026-9"
+         x="92.261368"
+         y="105.54913"
+         style="font-size:1.41111px;fill:#666666;fill-opacity:1;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none">0</tspan></text>
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3"
+       id="path8156"
+       d="m 107.6578,106.01693 c 0.47333,-0.42491 0.93997,-0.85468 1.42518,-1.27156 0.14576,-0.12523 0.28865,-0.25286 0.4444,-0.37066 0.12624,-0.0955 0.26688,-0.17887 0.40032,-0.26831 0.11703,-0.0497 0.44237,-0.22463 0.35109,-0.14918 -0.21023,0.17378 -0.56051,0.24504 -0.71576,0.45061 -0.0545,0.0722 0.19489,0.0755 0.27814,0.12886 0.27388,0.17543 0.43756,0.42507 0.59848,0.66326 0.39905,0.6376 0.23848,0.59058 1.54265,-0.11524 0.0986,-0.0534 0.11635,-0.16322 0.16972,-0.24674 0.0682,-0.10678 0.12995,-0.21598 0.19492,-0.32396 0.18068,-0.30441 0.20447,-0.34389 0.37879,-0.63987 0.0494,-0.0838 0.0894,-0.17129 0.14774,-0.25157 0.0395,-0.0544 0.21624,-0.17813 0.14426,-0.15014 -1.09152,0.42446 -1.22707,0.34302 -0.7789,0.49661 0.0565,0.0514 0.12016,0.0987 0.16959,0.1544 0.19475,0.21937 0.31455,0.4753 0.44806,0.71835 0.13288,0.24187 0.11501,0.20731 0.25168,0.43288 0.0606,0.0891 0.13969,0.23506 0.257,0.29642 0.14639,0.0765 0.32903,0.0774 0.4853,0.0153 1.0977,-0.43664 0.96749,-0.37082 1.53305,-0.73052 0.0732,-0.0516 0.14636,-0.10324 0.21965,-0.15478 0.11824,-0.0831 0.22529,-0.17695 0.35471,-0.24939 0.0423,-0.0237 0.18305,-0.0773 0.13962,-0.0549 -0.98267,0.50733 -1.27202,0.3137 -0.8117,0.54624 0.0487,0.0463 0.10134,0.0901 0.14626,0.13865 0.11813,0.12753 0.16387,0.20391 0.25292,0.34385 0.064,0.10064 0.10639,0.20155 0.21446,0.28106 0.0389,0.0287 0.0914,0.0438 0.13712,0.0656 0.0616,-6.2e-4 0.12463,0.009 0.18474,-0.002 0.0682,-0.0118 0.13201,-0.0369 0.19277,-0.0636 0.42628,-0.18715 0.8469,-0.38196 1.26703,-0.57729 0.23172,-0.10773 -0.46887,0.20832 -0.70178,0.3145 -0.11892,0.0542 0.23921,-0.10659 0.35976,-0.15859 0.11233,-0.0484 0.22589,-0.0952 0.33883,-0.14276 0.23348,-0.10566 0.44542,-0.18262 0.70051,-0.0755 0.14628,0.0614 0.25098,0.17349 0.39915,0.23211 0.0973,0.0385 0.20714,0.0537 0.31071,0.0806 0.19431,-0.0158 0.39113,-0.0184 0.58291,-0.0473 0.38035,-0.0572 1.21866,-0.25954 1.57978,-0.34602 0.60943,-0.14596 1.21133,-0.29683 1.83005,-0.41729 0.11791,-0.007 0.2359,-0.0298 0.35373,-0.0217 0.47066,0.032 0.60811,0.45291 0.72511,0.73731 0.0617,0.0423 0.11227,0.0971 0.18509,0.12699 0.40568,0.16647 1.2292,-0.10643 1.63766,-0.21065 0.27891,-0.048 0.60263,-0.19188 0.89367,-0.10031 0.14743,0.0464 0.20434,0.10805 0.31736,0.19364 0.21953,0.17255 0.44698,0.48877 0.73505,0.59425 0.039,0.0143 0.0828,0.0187 0.12422,0.028 0.0429,-0.002 0.0866,0.002 0.1288,-0.004 0.0939,-0.0142 0.22333,-0.065 0.30806,-0.0927 0.15723,-0.0514 0.31627,-0.094 0.47896,-0.13352 0.0988,-0.0125 0.20423,-0.0612 0.30821,-0.0485 0.16841,0.0205 0.32846,0.11826 0.46657,0.18626 0.21246,0.0876 0.42819,0.30574 0.66863,0.34166 0.21289,0.0318 0.29837,-0.0189 0.50927,-0.0735 0.73929,-0.30033 0.46569,-0.1839 1.66874,-0.74011 0.0965,-0.0446 0.37953,-0.18651 0.28248,-0.14261 -1.62927,0.7371 -0.94585,0.36026 -0.61997,0.34438 0.0478,-0.002 0.0949,0.009 0.14236,0.0141 0.0478,0.0268 0.0997,0.0497 0.14347,0.0804 0.0601,0.0421 0.10667,0.095 0.16686,0.13709 0.28945,0.20236 0.63082,0.35844 0.97134,0.50243 0.3443,0.13607 0.73156,0.15941 1.11034,0.18185 0.009,4.1e-4 0.1375,1.2e-4 0.16064,0.0194 0.10288,0.0856 0.19913,0.49747 0.2324,0.61809 0.0352,0.11797 0.0341,0.19415 0.14157,0.28545 0.0635,0.054 0.17716,0.0958 0.27283,0.0542 1.14441,-0.49674 0.92654,-0.2985 1.30573,-0.69954 0.0298,-0.03 0.18741,-0.19338 0.23264,-0.22078 0.034,-0.0206 0.15566,-0.0572 0.11906,-0.0395 -0.32842,0.15922 -0.68847,0.28163 -0.9957,0.46448 -0.0362,0.0215 0.0791,0.0367 0.11125,0.0619 0.0468,0.0366 0.0823,0.081 0.12341,0.12158 0.0863,0.0958 0.12774,0.16785 0.26737,0.22374 0.11482,0.0459 0.24849,0.0507 0.36379,-7.7e-4 1.21798,-0.54703 0.97151,-0.29175 1.34289,-0.75835 0.18915,-0.25886 0.251,-0.55403 0.38474,-0.82908 0.01,-0.0177 0.0135,-0.0382 0.0289,-0.0533 0.009,-0.009 0.0531,-0.0199 0.0403,-0.0142 -0.35984,0.16143 -0.72944,0.31018 -1.08166,0.48137 -0.014,0.007 0.0239,0.0177 0.0338,0.0279 0.0529,0.0541 0.0698,0.0816 0.11333,0.14078 0.0486,0.069 0.0776,0.14395 0.10561,0.21899 0,0 1.10505,-0.4705 1.10505,-0.4705 v 0 c -0.0364,-0.0792 -0.0717,-0.15896 -0.12308,-0.2333 -0.0108,-0.0153 -0.16423,-0.23459 -0.17101,-0.2325 -1.0581,0.32643 -1.0493,0.15506 -1.18963,0.55017 -0.0918,0.27053 -0.15558,0.54969 -0.35776,0.78855 -0.36197,0.36143 -0.18809,0.14498 0.73545,-0.20874 0.0521,-0.02 -0.0903,0.0599 -0.14518,0.0748 -0.1922,0.0521 -0.31712,-0.0816 -0.39957,-0.18889 -0.005,-0.006 -0.23944,-0.27457 -0.26489,-0.26838 -0.81242,0.19792 -1.10618,0.3209 -1.50842,0.73791 -0.37577,0.33228 -0.11789,0.0769 0.80543,-0.27182 0.0379,-0.0143 -0.052,0.0562 -0.0914,0.0679 -0.078,0.0232 -0.15755,-0.0534 -0.18091,-0.092 -0.0305,-0.0504 -0.0389,-0.10719 -0.0584,-0.16077 -0.082,-0.2958 -0.0252,-0.0955 -0.11179,-0.38937 -0.032,-0.10879 -0.0468,-0.32928 -0.22558,-0.37092 -0.0351,-0.008 -0.0733,7.8e-4 -0.10998,0.002 -0.37518,-0.003 -0.75609,-0.0204 -1.10631,-0.13485 -0.34222,-0.12332 -0.68195,-0.25912 -0.94985,-0.47043 -0.0601,-0.0474 -0.10558,-0.10505 -0.16341,-0.15419 -0.0523,-0.0445 -0.11108,-0.0841 -0.16662,-0.12621 -0.0589,-0.0126 -0.11575,-0.0346 -0.17671,-0.0377 -0.49535,-0.0258 -1.45693,0.55625 -1.46779,0.56109 -0.0932,0.0414 -0.36637,0.17358 -0.27039,0.13611 0.23301,-0.091 0.45502,-0.19794 0.68247,-0.29699 0.10516,-0.0458 -0.2104,0.0915 -0.31559,0.13722 -0.14625,0.0498 -0.26486,0.10963 -0.42793,0.10722 -0.22048,-0.003 -0.48435,-0.22497 -0.66552,-0.31135 -0.13278,-0.0746 -0.40323,-0.26099 -0.5796,-0.26493 -0.0825,-0.002 -0.15795,0.0498 -0.24009,0.0468 -0.16518,0.0399 -0.33103,0.0787 -0.49197,0.12829 -0.42289,0.13028 0.0816,-0.0224 -0.27671,0.1026 -0.0338,0.0118 -0.07,0.0188 -0.10506,0.0283 -0.0357,7.8e-4 -0.0721,0.008 -0.10723,0.002 -0.26293,-0.0392 -0.57146,-0.40647 -0.73762,-0.55581 -0.14882,-0.12858 -0.29905,-0.26909 -0.53721,-0.29492 -0.26911,-0.0292 -0.52979,0.0919 -0.78343,0.13271 -0.24149,0.064 -0.45952,0.12323 -0.70382,0.1816 -0.24832,0.0593 -0.56382,0.15387 -0.82897,0.0836 -0.0582,-0.0154 -0.10358,-0.0514 -0.15537,-0.0772 -0.12138,-0.25082 -0.23441,-0.59126 -0.55169,-0.74122 -0.26776,-0.12657 -0.39161,-0.0732 -0.69743,-0.05 -0.64415,0.13871 -1.27261,0.30725 -1.91055,0.46178 -0.4332,0.10493 -1.041,0.24883 -1.49482,0.31539 -0.16304,0.0239 -0.32978,0.0288 -0.49468,0.0432 -0.0913,-0.0195 -0.18887,-0.0261 -0.27378,-0.0585 -0.0557,-0.0213 -0.36187,-0.23174 -0.40908,-0.2556 -0.31158,-0.15741 -0.49654,-0.10755 -0.80455,0.0308 -0.68436,0.28689 -1.36078,0.58396 -2.02985,0.89223 -0.26777,0.12338 0.54057,-0.24017 0.81391,-0.35599 0.0989,-0.0419 -0.3359,0.16863 -0.29619,0.1264 -0.0393,-0.008 -0.0839,-0.006 -0.11778,-0.0233 -0.11142,-0.0567 -0.16584,-0.16918 -0.22242,-0.2534 -0.12211,-0.18173 -0.24529,-0.36287 -0.40758,-0.52589 -0.0526,-0.0372 -0.0892,-0.12691 -0.1577,-0.11168 -1.07024,0.23828 -1.22335,0.40953 -1.89273,0.87515 -0.41456,0.24118 -0.53747,0.29851 0.53021,-0.18662 0.0447,-0.0203 -0.21771,0.13154 -0.39487,0.0662 -0.10896,-0.0402 -0.20797,-0.19713 -0.25999,-0.26432 -0.15525,-0.22662 -0.12291,-0.17026 -0.26587,-0.42011 -0.14249,-0.24904 -0.26685,-0.51042 -0.44429,-0.74651 -0.0498,-0.0662 -0.11186,-0.12647 -0.16779,-0.18971 -0.0632,-0.0431 -0.11057,-0.15226 -0.18955,-0.12952 -0.42526,0.12243 -0.80579,0.32652 -1.18101,0.52409 -0.061,0.0322 -0.0725,0.0998 -0.10279,0.15192 -0.16813,0.28979 -0.29566,0.59442 -0.4943,0.87388 -0.0761,0.10831 -0.14259,0.22102 -0.22834,0.32493 -0.069,0.0836 -0.36083,0.25298 -0.23457,0.23598 2.20038,-0.29612 1.08471,-0.16764 0.86036,-0.38732 -0.0321,-0.0315 -0.22739,-0.30134 -0.2343,-0.31076 -0.18318,-0.24252 -0.36645,-0.50267 -0.63477,-0.69716 -0.0915,-0.0663 -0.17984,-0.19018 -0.30297,-0.1723 -0.80579,0.11699 -1.1045,0.29031 -1.6488,0.56527 -0.11935,0.0879 -0.24399,0.17165 -0.35805,0.26364 -0.14571,0.11753 -0.28081,0.24268 -0.42062,0.36441 -0.52396,0.45626 -1.04925,0.91189 -1.61418,1.33841 0,0 1.1676,-0.38646 1.1676,-0.38646 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3"
+       id="path8158"
+       d="m 108.20135,96.505406 c -0.002,-0.121252 -0.0265,-0.245724 10e-4,-0.366362 0.0107,-0.04627 0.0641,-0.17174 0.0819,-0.215362 0.0474,-0.07036 0.0533,-0.170913 0.13165,-0.229237 0.0181,-0.01351 0.0876,-0.03883 0.066,-0.0287 -1.02649,0.479182 -1.38665,0.445128 -0.88365,0.469283 0.29656,0.0696 0.53533,0.219807 0.76705,0.371381 0.11829,0.09768 0.26143,0.171896 0.43235,0.198146 0.39892,-0.182492 0.814,-0.345615 1.19676,-0.547458 0.0115,-0.0061 0.2561,-0.314884 0.26511,-0.326248 0.11718,-0.147962 0.23234,-0.29682 0.34676,-0.446041 0.0272,-0.02993 0.0484,-0.06361 0.0816,-0.08973 0.0226,-0.01788 0.11044,-0.05249 0.0826,-0.03967 -0.34063,0.156817 -0.70077,0.291229 -1.02093,0.471655 -0.0325,0.01834 0.0749,0.02463 0.10693,0.04343 0.1089,0.06392 0.21688,0.167683 0.30453,0.244458 0.2679,0.25347 0.52577,0.512484 0.80709,0.757405 0.45516,0.398253 0.57739,-0.0109 1.37676,-0.409946 0.0469,-0.204184 0.1125,-0.40321 0.18567,-0.602429 0.0337,-0.114991 0.0629,-0.205226 0.22003,-0.241512 -1.8915,0.851514 -1.30637,0.399687 -0.87153,0.461884 0.23701,0.03392 0.46644,0.130022 0.68143,0.209924 0.13815,0.0478 0.27305,0.1017 0.41688,0.138908 1.3245,0.04213 0.86425,-0.514118 1.44776,-0.752402 -1.74986,0.773419 -1.16126,0.440923 -0.69996,0.385118 0.15755,-0.01911 0.31399,-0.02317 0.47304,-0.02294 0.3069,0.0078 0.55619,0.135384 0.80556,0.258355 0.50395,0.182374 1.11396,0.16248 1.65857,0.148806 0.43206,-0.01542 0.86332,-0.04105 1.29484,-0.06315 0.14518,-0.01174 0.27534,0.04044 0.40894,0.07527 0.48646,0.103594 0.69498,-0.211312 1.2543,-0.488451 2.6e-4,-1.77e-4 0.066,-0.177896 0.0722,-0.194293 0.0183,-0.05272 0.0816,-0.08553 0.11671,-0.128486 0.0364,-0.0445 0.0592,-0.09482 0.0901,-0.141724 0.16645,-0.216085 0.25101,-0.482221 0.46513,-0.674893 -0.33626,0.157752 -0.68068,0.305706 -1.00879,0.473256 -0.0218,0.01113 0.0547,-0.0069 0.0784,0.0015 0.0571,0.02041 0.10649,0.05202 0.15602,0.0819 0.23527,0.141939 0.42527,0.313149 0.61913,0.486556 0.22182,0.179461 0.35426,0.422945 0.61956,0.569089 0.15486,0.06752 0.33164,0.06461 0.50408,0.06192 0.2551,-0.0061 0.51033,-0.0081 0.76553,-0.0061 0.59968,0.01826 0.60238,-0.165402 1.38634,-0.533337 0.17204,-0.460897 0.93795,-0.647233 -0.78679,0.153116 0.0109,-6.06e-4 0.0255,-0.0082 0.0327,-0.0023 0.063,0.05456 0.26584,0.334844 0.27719,0.35085 0.2188,0.3083 0.41753,0.62473 0.61341,0.941816 0.10101,0.101915 0.25931,0.521584 0.41949,0.585648 0.0609,0.0244 0.14605,0.03438 0.20582,0.0084 1.24319,-0.540652 1.02873,-0.370959 1.50606,-0.939948 0.36355,-0.433148 0.66154,-0.896117 1.00744,-1.337163 0.18619,-0.237414 0.24632,-0.292799 0.45354,-0.514982 0.073,-0.07167 0.14472,-0.14418 0.21912,-0.215027 0.026,-0.02471 0.29096,-0.269749 0.3424,-0.307563 0.0392,-0.02885 0.17709,-0.09623 0.13041,-0.07489 -1.02985,0.470074 -1.28321,0.27898 -0.90509,0.515775 0.26954,0.381786 0.37699,0.81763 0.51034,1.236308 0.0702,0.162962 0.0667,0.341817 0.1545,0.500015 0.052,0.08754 0.152,0.104282 0.26666,0.08967 0.14165,-0.0488 0.28951,-0.08534 0.44232,-0.106223 0.18298,-0.02624 0.28668,0.117196 0.37714,0.216541 0.20067,0.241289 0.28129,0.253298 0.62197,0.121843 0.39928,-0.181072 0.80112,-0.358879 1.19785,-0.543228 0.0441,-0.02049 0.0815,-0.04842 0.12387,-0.0709 0.0339,-0.01803 0.0699,-0.03361 0.10487,-0.05041 -0.33069,0.14899 -0.66449,0.293976 -0.99207,0.446967 -0.0152,0.0069 0.035,-0.01128 0.0522,-0.008 0.0249,0.0046 0.0438,0.02041 0.0658,0.03062 0.0228,0.01749 0.12709,0.09984 0.15448,0.112044 0.0723,0.03223 0.15811,0.04489 0.23635,0.0109 1.1129,-0.483116 0.86788,-0.297363 1.26539,-0.620896 0.10401,-0.08779 0.17672,-0.19571 0.27658,-0.285733 0.20453,-0.184377 -0.0881,0.100573 0.0933,-0.07863 0.34699,-0.205977 0.87206,-0.394815 -0.96531,0.423728 -0.006,0.0031 0.0103,-0.01473 0.0156,-0.01113 0.031,0.02095 0.0548,0.04773 0.0777,0.07412 0.0448,0.05156 0.0833,0.106167 0.12492,0.15925 0.27225,0.357191 0.45103,0.751929 0.71862,1.110442 0.0376,0.01934 0.0712,0.07159 0.11281,0.05793 0.42533,-0.139936 0.83204,-0.313402 1.22685,-0.498657 0.0618,-0.029 0.0861,-0.08944 0.12569,-0.135969 0.14331,-0.168501 0.27055,-0.345798 0.39616,-0.522232 0.1184,-0.131802 0.20054,-0.286763 0.3316,-0.412325 0.0146,-0.01396 0.0338,-0.02478 0.0507,-0.03714 -0.34688,0.159777 -0.69376,0.319548 -1.04064,0.479327 0.0184,0.0031 0.041,-4.06e-4 0.0553,0.0091 0.0833,0.05433 0.19035,0.185326 0.24344,0.249098 0.11442,0.137443 0.21686,0.279748 0.31777,0.423145 0.0959,0.138171 0.23943,0.251564 0.45711,0.160523 1.05706,-0.442105 0.88682,-0.350466 1.39848,-0.652074 0.1393,-0.0891 0.26846,-0.188749 0.41165,-0.274351 0.0297,-0.01772 0.12578,-0.06315 0.0932,-0.04873 -1.22102,0.541217 -1.33826,0.588492 -0.96977,0.438458 0.0224,0.01719 0.0487,0.03184 0.0673,0.05149 0.22406,0.235297 0.35997,0.527053 0.50683,0.793397 0.0559,0.08859 0.0803,0.221485 0.20453,0.276318 0.0718,0.03169 0.15671,0.03376 0.22956,0.0015 0.39535,-0.173067 0.77989,-0.360309 1.16983,-0.54046 0.11757,-0.09072 0.21811,-0.189987 0.36018,-0.258654 -1.77545,0.7952 -1.35198,0.50148 -0.89021,0.436925 0.1329,0.04243 0.19862,0.186551 0.25478,0.281858 0.0465,0.09101 0.0736,0.162902 0.21995,0.156242 0.14412,-0.04558 0.28092,-0.101655 0.43074,-0.136798 0.0601,-0.0054 0.12616,-0.03223 0.18457,-0.03115 0.058,0.02594 0.071,0.06952 0.11003,0.109504 0.0684,0.07643 0.15886,0.134389 0.2627,0.180198 0.0661,0.02248 0.155,0.05195 0.2263,0.02102 1.10308,-0.478852 0.83475,-0.291221 1.22544,-0.57601 0.3161,-0.22846 0.99978,-0.479696 -0.89076,0.377765 -0.0162,0.0077 0.0314,-0.01826 0.05,-0.01995 0.0547,-0.0054 0.10145,0.02755 0.14206,0.04711 0.0868,0.04512 0.14811,0.112091 0.23454,0.157547 0.36876,0.193935 1.23427,-0.449602 1.32784,-0.49202 0.18925,-0.159656 0.33145,-0.346051 0.49324,-0.521507 0.0895,-0.08688 0.14312,-0.194667 0.23023,-0.28254 0.0641,-0.06469 0.005,0.01865 0.0464,-0.04474 0.0271,-0.129846 0.0387,-0.264391 0.0597,-0.39601 0.0106,-0.08783 0.005,-0.04581 0.0154,-0.126009 0,0 -1.13344,0.435219 -1.13344,0.435219 v 0 c -0.005,0.07658 -0.002,0.03637 -0.0103,0.120593 -0.0136,0.120254 -0.0133,0.259827 -0.10359,0.362917 -0.097,0.09266 -0.13536,0.22262 -0.24384,0.310893 -0.15799,0.176261 -0.30689,0.362143 -0.52216,0.501642 0.33588,-0.143612 0.6678,-0.292793 1.00762,-0.430818 8e-4,-4.07e-4 -0.036,0.061 -0.10136,0.04427 -0.0997,-0.02548 -0.15399,-0.113878 -0.23766,-0.156303 -0.0484,-0.03092 -0.12021,-0.08069 -0.17813,-0.102297 -0.4877,-0.181916 -0.96937,0.329693 -1.35219,0.576852 -0.39759,0.235291 5.3e-4,-0.0046 0.9305,-0.395598 0.0525,-0.02202 -0.0485,0.05678 -0.11559,0.05103 -0.0115,-7.67e-4 -0.0228,-0.0023 -0.0343,-0.0031 -0.097,-0.02785 -0.17948,-0.06791 -0.23186,-0.139353 -0.0395,-0.04013 -0.0506,-0.109763 -0.11683,-0.130734 -0.0901,-0.07205 -0.14611,-0.05885 -0.26767,-0.0419 -0.15002,0.02862 -0.30385,0.06192 -0.43148,0.131256 -0.0121,0.0077 -0.0259,0.01366 -0.0363,0.02256 -0.0103,0.0087 -0.005,0.032 -0.0206,0.03161 -0.0354,-7.68e-4 -0.0448,-0.08216 -0.0697,-0.09074 -0.0858,-0.123877 -0.16502,-0.263153 -0.3012,-0.358194 -0.44465,-0.171133 -1.33425,0.641962 -1.34941,0.481592 -0.11577,0.08099 -0.20799,0.180144 -0.33417,0.252847 0.32341,-0.139821 0.64257,-0.285596 0.97024,-0.419453 0.0527,-0.02156 -0.0833,0.07975 -0.14294,0.08297 -0.11592,0.0061 -0.16089,-0.177203 -0.20542,-0.218968 -0.0654,-0.105238 -0.13343,-0.209517 -0.19646,-0.315589 -0.0999,-0.168174 -0.18472,-0.346203 -0.30144,-0.508269 -0.0256,-0.03553 -0.0589,-0.06737 -0.0883,-0.101118 -0.0343,-0.01842 -0.065,-0.06921 -0.10278,-0.05532 -0.80994,0.297537 -1.06566,0.456958 -1.62134,0.826774 -0.49131,0.266544 -0.0665,0.02908 0.70764,-0.286047 0.0433,-0.01757 -0.0729,0.05133 -0.11594,0.06921 -0.11738,0.04888 -0.19066,-0.05095 -0.24322,-0.111231 -0.114,-0.138555 -0.22606,-0.27775 -0.3347,-0.418837 -0.0417,-0.05417 -0.1756,-0.23476 -0.23004,-0.291219 -0.0334,-0.03461 -0.0746,-0.0643 -0.11191,-0.09643 -0.37798,0.167322 -0.76151,0.327452 -1.13393,0.501963 -0.008,0.0038 -0.0745,0.09929 -0.0799,0.106873 -0.0807,0.113298 -0.1613,0.226654 -0.24121,0.340294 -0.12368,0.173067 -0.24654,0.356564 -0.4163,0.506721 -0.0482,0.04259 -0.22873,0.137594 -0.16117,0.115426 1.19757,-0.392996 1.32834,-0.383082 0.89305,-0.383343 -0.31517,-0.332517 -0.51459,-0.720185 -0.73795,-1.091244 -0.0336,-0.05901 -0.12122,-0.225408 -0.17974,-0.292017 -0.0229,-0.02609 -0.0453,-0.08295 -0.0826,-0.0699 -0.46396,0.161511 -0.91179,0.273348 -1.21126,0.559388 -0.12386,0.112366 -0.21482,0.245082 -0.3543,0.347949 -0.37665,0.268113 -0.082,0.04711 0.87108,-0.342033 0.0532,-0.02172 -0.0943,0.08139 -0.15354,0.07313 -0.0469,-0.0061 -0.13471,-0.09544 -0.15467,-0.113195 -0.0158,-0.01143 -0.15479,-0.1227 -0.19479,-0.108267 -0.40302,0.14539 -0.77793,0.332847 -1.16411,0.503038 -0.0761,0.03353 -0.29143,0.149309 -0.21445,0.117035 0.30908,-0.129603 0.61254,-0.266938 0.91881,-0.400406 -0.0477,0.02287 -0.2564,0.138048 -0.3156,0.14167 -0.0886,0.0054 -0.14763,-0.119817 -0.19262,-0.153318 -0.11423,-0.124189 -0.22587,-0.290245 -0.44042,-0.313771 -0.15682,0.01688 -0.31171,0.04021 -0.45877,0.08724 -0.0392,0.02325 -0.11601,0.07871 -0.15569,0.03177 -0.0998,-0.142415 -0.11257,-0.315919 -0.19667,-0.463529 -0.17549,-0.427548 -0.29349,-0.870014 -0.51456,-1.285324 -0.0404,-0.03967 -0.0589,-0.13511 -0.12108,-0.119058 -1.12812,0.291229 -1.22863,0.451781 -1.79785,1.052284 -0.20728,0.232903 -0.24918,0.270348 -0.43453,0.518582 -0.33102,0.443317 -0.61347,0.909283 -1.00381,1.325645 -0.0989,0.09908 -0.45909,0.292769 -0.29658,0.297219 0.29849,0.0082 0.5384,-0.199601 0.81662,-0.282962 0.0524,-0.01565 -0.0781,0.08137 -0.13417,0.0785 -0.14643,-0.0077 -0.40608,-0.464749 -0.47072,-0.531767 -0.2073,-0.314858 -0.40664,-0.62928 -0.58762,-0.95364 -0.0462,-0.08273 -0.0907,-0.165987 -0.13708,-0.24865 -0.0314,-0.05594 -0.0551,-0.115012 -0.0961,-0.167159 -0.028,-0.0356 -0.0723,-0.062 -0.10837,-0.09295 -0.37778,0.171624 -0.76197,0.335186 -1.13333,0.51487 -0.0701,0.03391 -0.16569,0.273463 -0.24783,0.325817 0.35412,-0.157254 0.70824,-0.314499 1.06236,-0.471746 -0.0295,0.01327 -0.0741,0.04167 -0.10639,0.0478 -0.0492,0.0094 -0.10338,-0.0079 -0.15212,0.0038 -0.25487,0.0046 -0.50983,0.0061 -0.76477,0.0054 -0.15298,-4.07e-4 -0.31041,0.0109 -0.45952,-0.02033 -0.28539,-0.105591 -0.43394,-0.354999 -0.65909,-0.515108 -0.1961,-0.174471 -0.38926,-0.350111 -0.6007,-0.513919 -0.049,-0.03798 -0.0975,-0.0765 -0.15007,-0.111574 -0.0414,-0.02762 -0.0812,-0.09377 -0.13118,-0.07643 -0.40228,0.139706 -0.75993,0.345223 -1.1399,0.517832 -0.15364,0.223979 -0.2718,0.462483 -0.44898,0.677187 -0.08,0.09576 -0.17536,0.182858 -0.21344,0.295194 -0.0135,0.0297 -0.034,0.08156 -0.0589,0.107041 -0.0136,0.01396 -0.0713,0.04266 -0.0514,0.0343 0.35332,-0.149021 0.70196,-0.304455 1.05294,-0.456684 -0.0384,0.03645 -0.0137,0.02494 -0.0748,0.03399 -0.15179,-0.02954 -0.29139,-0.09355 -0.44887,-0.09937 -0.45035,0.04312 -0.90118,0.08494 -1.35458,0.104179 -0.52044,0.0145 -1.07467,0.02839 -1.56271,-0.132309 -0.26694,-0.125677 -0.52193,-0.277315 -0.84514,-0.298854 -0.13326,-0.0061 -0.66421,-0.0046 -0.76946,0.03806 -0.39992,0.160782 -0.78643,0.340511 -1.17964,0.510764 -0.082,0.05602 -0.14043,0.11192 -0.20509,0.179705 -0.0189,0.01987 -0.0863,0.07044 -0.058,0.05893 1.01541,-0.411366 1.218,-0.728168 1.01432,-0.423674 -0.008,0.0054 -0.0136,0.01504 -0.0242,0.01696 -0.0771,0.01381 -0.31071,-0.09059 -0.38672,-0.09895 -0.23214,-0.0755 -0.46218,-0.157084 -0.69653,-0.228345 -0.0502,-0.01527 -0.10311,-0.05755 -0.1528,-0.04128 -0.40912,0.133637 -0.78692,0.317853 -1.18038,0.476773 -0.10646,0.08291 -0.14111,0.193984 -0.17109,0.305553 -0.0621,0.194439 -0.0908,0.398406 -0.20268,0.580575 0.34479,-0.147655 0.68422,-0.302938 1.03437,-0.442964 0.0211,-0.0084 -0.0108,0.04788 -0.0345,0.0478 -0.0602,-1.99e-4 -0.10879,-0.07497 -0.15644,-0.08974 -0.3128,-0.22128 -0.57925,-0.474594 -0.83423,-0.735411 -0.0286,-0.02831 -0.38462,-0.377722 -0.41697,-0.368782 -0.79583,0.219991 -1.02608,0.221594 -1.30423,0.603158 -0.14464,0.207611 -0.29159,0.419024 -0.47807,0.606785 -0.32034,0.322558 -0.57856,0.309667 0.81721,-0.252101 -0.0172,0.0069 -0.0322,0.01941 -0.0516,0.02087 -0.10693,0.0081 -0.26988,-0.102913 -0.34015,-0.151899 -0.25567,-0.146495 -0.50442,-0.30223 -0.79892,-0.402235 -0.046,-0.01565 -0.092,-0.06261 -0.13807,-0.04704 -1.02704,0.346627 -1.12615,0.258063 -1.32852,0.786632 -0.0296,0.08167 -0.0582,0.150385 -0.0734,0.234913 -0.0228,0.126171 -0.002,0.254762 -0.0193,0.381293 0,0 1.13248,-0.44277 1.13248,-0.44277 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3"
+       id="path8160"
+       d="m 108.21428,99.554353 c 0.004,-0.140627 -0.0358,-0.291997 0.0134,-0.429307 0.41714,-0.17749 -0.37836,0.16032 -0.97525,0.458837 -0.0223,0.0111 0.0528,-0.01 0.0792,-0.007 0.0378,0.004 0.074,0.0142 0.10962,0.0245 0.0862,0.0248 0.16217,0.0584 0.24312,0.0915 0.20322,0.0986 0.42173,0.16281 0.65285,0.20926 0.11848,0.0284 0.26337,0.0358 0.36371,0.0986 0.0453,0.0283 0.16286,0.13699 0.19397,0.16479 0.11034,0.0707 0.16302,0.1996 0.29007,0.25716 0.0358,0.0162 0.0823,0.0417 0.11957,0.0276 1.17898,-0.44816 0.9994,-0.22102 1.26654,-0.654453 0.14383,-0.26623 0.19387,-0.553437 0.31841,-0.824077 0.27106,-0.210247 1.19011,-0.63217 -0.89112,0.38607 -0.033,0.0162 0.075,-0.0208 0.11413,-0.0214 0.14212,-0.002 0.25455,0.0338 0.3887,0.0649 0.36229,0.088 0.66683,0.266057 1.00208,0.395837 0.75741,0.13515 1.22099,-0.428857 1.58718,-0.814377 0.24962,-0.259407 1.22963,-0.595181 -0.913,0.37418 -0.027,0.0122 0.0558,-0.0229 0.0861,-0.0293 0.44268,-0.12844 0.13343,-0.0367 1.16064,-0.522667 0.0244,-0.0115 0.0207,-0.0521 0.0289,-0.0666 0.01,-0.017 0.0319,-0.0277 0.0478,-0.0416 0.42737,-0.085 0.004,-0.003 -1.00892,0.463697 -0.0185,0.009 0.0397,-0.0132 0.0607,-0.017 0.14809,-0.0271 0.29422,-0.0233 0.44495,-0.0185 0.27797,0.0255 0.53961,0.10473 0.81033,0.15425 0.0469,-4e-4 0.0945,0.005 0.14055,-0.002 0.0584,-0.008 0.11773,-0.0198 0.16953,-0.0422 0.9404,-0.404967 1.11938,-0.427547 1.66424,-0.901204 0.16989,-0.177704 0.2354,-0.39539 0.29879,-0.606591 0.20567,-0.335413 0.12223,-0.171667 -1.00959,0.434407 -0.0216,0.01152 0.0486,0.01704 0.0684,0.0304 0.1043,0.07025 0.18572,0.167631 0.26404,0.254341 0.14604,0.18927 0.29996,0.36858 0.49412,0.531077 0.24907,0.19224 0.52352,0.36307 0.79263,0.537997 0.0707,0.0454 0.13567,0.1112 0.23245,0.12569 0.0856,0.0128 0.15906,-0.006 0.23264,-0.0395 0.39582,-0.179737 0.78526,-0.367627 1.17789,-0.551437 0.22933,-0.146767 0.37475,-0.346377 0.5571,-0.522977 0.34806,-0.238555 0.17576,-0.11448 -0.91602,0.40553 -0.0345,0.0164 0.0725,-0.0292 0.11185,-0.0369 0.15816,-0.0313 0.30806,-4.1e-4 0.46159,0.0277 0.28192,0.067 0.54073,0.199687 0.83329,0.242207 0.0659,0.01 0.13342,0.0103 0.20013,0.0155 0.37669,-0.022 0.73089,-0.13327 1.07671,-0.243067 0.0218,0.0151 0.18537,-0.0789 0.20547,-0.0773 0.0221,0.002 0.0405,0.014 0.0607,0.0209 0.19461,0.102427 0.38581,0.207647 0.58893,0.300047 0.0409,0.0193 0.0829,0.0365 0.1264,0.052 0,0 1.05668,-0.552887 1.05668,-0.552887 v 0 c -0.0447,-0.004 -0.0834,-0.0169 -0.12433,-0.0315 -0.21077,-0.0752 -0.41023,-0.16858 -0.58147,-0.290343 -0.17404,-0.118196 -0.153,-0.09418 -0.34863,-0.01942 -0.33949,0.122763 -0.69005,0.238463 -1.06057,0.291103 -0.0596,-7.7e-4 -0.11978,0.003 -0.17894,-0.003 -0.2953,-0.0296 -0.56381,-0.15846 -0.83513,-0.241523 -0.14082,-0.03355 -0.47161,-0.121965 -0.61379,-0.06165 -1.11461,0.472793 -0.88414,0.262673 -1.21572,0.584903 -0.1608,0.182377 -0.33039,0.359247 -0.5583,0.496917 0.31648,-0.13622 0.63013,-0.27638 0.94944,-0.40866 0.0346,-0.0143 -0.0621,0.0371 -0.0943,0.0544 -0.13789,0.0742 -0.16734,0.0257 -0.28583,-0.0466 -0.27469,-0.163607 -0.56197,-0.318277 -0.7918,-0.521217 -0.18749,-0.160332 -0.32798,-0.343126 -0.48101,-0.522893 -0.0857,-0.09375 -0.17512,-0.184414 -0.26784,-0.274134 -0.0317,-0.03063 -0.0487,-0.106515 -0.0958,-0.09157 -1.12094,0.355636 -1.0385,0.169579 -1.16149,0.549391 -0.0569,0.198571 -0.13119,0.397586 -0.30544,0.555906 -0.10043,0.0858 -0.14963,0.13234 -0.26564,0.21122 -0.0558,0.0379 -0.24088,0.133137 -0.17384,0.108067 0.30238,-0.113077 0.59,-0.248087 0.88393,-0.373617 0.0458,-0.0196 -0.0911,0.0402 -0.13949,0.0557 -0.0349,0.0111 -0.0727,0.0159 -0.10911,0.0239 -0.28315,-0.0381 -0.5572,-0.10735 -0.83865,-0.15177 -0.60807,-0.0691 -1.30745,0.0203 -1.67506,0.512337 -0.014,0.0187 -0.0222,0.0399 -0.0379,0.0577 -0.0117,0.0132 -0.0673,0.0373 -0.0493,0.0293 0.98157,-0.433067 1.41263,-0.634717 1.02446,-0.453397 -0.0557,0.0253 -0.0245,0.0177 -0.0944,0.02 -0.71363,0.309267 -0.94002,0.277727 -1.23507,0.626037 -0.0666,0.0733 -0.13241,0.150247 -0.21061,0.216737 -0.0294,0.025 -0.13373,0.085 -0.0944,0.0703 1.28314,-0.481897 1.34202,-0.491137 0.91434,-0.390297 -0.36182,-0.0973 -0.66814,-0.29184 -1.03242,-0.387947 -0.0518,-0.0157 -0.47104,-0.14635 -0.52486,-0.12576 -0.47109,0.18015 -1.04263,0.263747 -1.23283,0.633917 -0.0854,0.268607 -0.1295,0.549077 -0.31191,0.79313 -0.038,0.0353 -0.16857,0.12466 -0.11406,0.10598 0.34196,-0.11719 0.6592,-0.27299 0.99088,-0.406443 0.0252,-0.0101 -0.0428,0.0385 -0.0711,0.0363 -0.0941,-0.007 -0.22604,-0.19421 -0.29087,-0.23675 -0.0869,-0.0847 -0.17096,-0.19842 -0.29427,-0.256057 -0.084,-0.0392 -0.20406,-0.0425 -0.29558,-0.0637 -0.22291,-0.0415 -0.44128,-0.0953 -0.6395,-0.18637 -0.53599,-0.236047 -1.29525,-0.536627 -1.63941,0.384137 -0.009,0.14752 0.009,0.29562 -0.007,0.44312 0,0 1.13248,-0.44302 1.13248,-0.44302 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3"
+       id="path8166"
+       d="m 110.42557,109.84915 c 0.22771,-0.0495 0.45404,-0.10274 0.68128,-0.15395 0.12203,-0.0149 0.26664,-0.10104 0.39643,-0.0739 0.0253,0.006 0.0476,0.0172 0.0713,0.0258 0.25937,0.15483 0.45084,0.3649 0.67952,0.54443 0.0261,0.0126 0.0489,0.0313 0.0784,0.0378 0.0353,0.008 0.0783,0.0182 0.10982,0.003 0.39053,-0.18307 0.77453,-0.37625 1.13978,-0.58922 0.0784,-0.0457 0.14891,-0.39232 0.16635,-0.45815 0.0816,-0.38522 0.18327,-0.76687 0.31168,-1.14406 0.16683,-0.31193 0.89477,-0.66171 -0.91329,0.37111 -0.0331,0.0189 0.083,0.002 0.12133,0.0133 0.13775,0.0398 0.26586,0.11884 0.3842,0.18293 0.24993,0.15668 0.48029,0.33098 0.71278,0.5031 0.20295,0.15206 0.39842,0.3105 0.59743,0.46591 0.12565,0.0964 0.25092,0.19266 0.3744,0.29082 0.15188,0.12077 0.2706,0.26612 0.42683,0.38299 0.7224,0.1886 1.41116,-0.59949 1.87987,-0.96838 0.52513,-0.28702 -0.56491,0.2413 -0.82358,0.39015 -0.0376,0.0216 0.0937,-0.002 0.1394,0.005 0.18841,0.0283 0.36447,0.11218 0.53284,0.17978 0.20125,0.0742 0.39093,0.16794 0.59716,0.23364 0.4867,0.1455 0.80013,-0.26831 1.28684,-0.4967 0.0498,-0.0234 0.10233,-0.0731 0.13964,-0.10445 0.37408,-0.34828 1.23107,-0.67495 -0.57419,0.15795 0.0741,-0.0317 0.15182,-0.061 0.23579,-0.0706 0.0482,-0.005 0.0969,-0.002 0.14528,-0.002 0.19922,-0.002 0.39773,-0.008 0.59646,0.005 0.3433,0.0451 0.64494,0.1903 0.94905,0.31577 0.29419,0.11743 0.37369,0.15848 0.69471,0.048 0.52703,0.0478 1.13812,-0.5775 1.64746,-0.795 -1.97742,0.93846 -1.27644,0.47543 -0.84618,0.43326 0.12484,-0.0122 0.25202,-0.0117 0.37755,-0.0132 0.15394,-0.006 0.30507,0.0143 0.45296,0.0459 0.0686,0.006 0.10802,0.0213 0.16372,0.0499 0.10538,0.05 0.21519,0.0923 0.32972,0.12757 0.0758,0.0232 0.15156,0.0452 0.23248,0.0534 0.0113,6.2e-4 0.0226,0.002 0.0339,0.002 0,0 1.03809,-0.58987 1.03809,-0.58987 v 0 c -0.0107,1.3e-4 -0.0215,2.1e-4 -0.0322,4.2e-4 -0.0761,0.002 -0.14847,-0.006 -0.22095,-0.0258 -0.10967,-0.0268 -0.21676,-0.0605 -0.30641,-0.11797 -0.0663,-0.0249 -0.10643,-0.0756 -0.18793,-0.0706 -0.16124,-0.029 -0.3258,-0.0614 -0.49199,-0.0554 -0.8618,0.006 -0.58874,-0.0263 -1.72526,0.52309 -0.3798,0.23106 -1.25536,0.65668 0.50378,-0.18115 -0.28669,0.14372 -0.32116,0.13129 -0.62658,0.0271 -0.32098,-0.11692 -0.62382,-0.27016 -0.96754,-0.34277 -0.19162,-0.0317 -0.38452,-0.0255 -0.57985,-0.03 -0.0494,-7.9e-4 -0.0987,-0.002 -0.14795,-0.006 -0.0998,-4.1e-4 -0.19247,0.0102 -0.28426,0.0447 -0.91473,0.41836 -1.03097,0.39847 -1.57121,0.84195 -0.0286,0.0187 -0.0567,0.0379 -0.0859,0.0559 -0.0238,0.0147 -0.0995,0.0536 -0.0731,0.0421 0.34886,-0.15273 0.68932,-0.31736 1.04109,-0.46588 0.0145,-0.006 -0.008,0.0271 -0.021,0.0352 -0.008,0.005 -0.0689,-0.005 -0.0732,-0.006 -0.21932,-0.0412 -0.41944,-0.12929 -0.62445,-0.20034 -0.17749,-0.0709 -0.3541,-0.15622 -0.54101,-0.21113 -0.0517,-0.0152 -0.10872,-0.0524 -0.15939,-0.0351 -1.00456,0.34077 -0.89538,0.2754 -1.31177,0.57564 -0.13519,0.11478 -0.26221,0.24125 -0.41032,0.34592 -0.052,0.0368 -0.2281,0.12568 -0.16528,0.10157 0.41964,-0.16105 1.31801,-0.56819 0.90546,-0.38149 -0.17598,-0.0916 -0.28165,-0.24977 -0.41707,-0.37372 -0.12306,-0.10254 -0.25924,-0.19206 -0.39409,-0.28453 -0.20228,-0.15367 -0.40035,-0.30987 -0.58954,-0.47338 -0.24414,-0.17262 -0.51114,-0.32387 -0.75794,-0.49419 -0.0436,-0.0261 -0.48264,-0.29361 -0.51796,-0.28149 -0.82984,0.28466 -1.09234,0.21866 -1.22033,0.65227 -0.0846,0.37814 -0.16697,0.75728 -0.28225,1.13044 -0.0464,0.12749 -0.0707,0.21765 -0.14194,0.33505 -0.0221,0.0364 -0.12502,0.1205 -0.0782,0.1042 0.34479,-0.11997 0.65592,-0.29351 0.99499,-0.4232 0.027,-0.0103 -0.0212,0.0482 -0.0468,0.0606 -0.0185,0.009 -0.0429,-0.005 -0.0644,-0.007 -0.26721,-0.14644 -0.44882,-0.37583 -0.68315,-0.5514 -0.0311,-0.0226 -0.0577,-0.0497 -0.0933,-0.0677 -0.13277,-0.0677 -0.32271,0.0138 -0.44917,0.0439 -0.21267,0.0605 -0.4372,0.0994 -0.65439,0.14616 0,0 -1.01453,0.61092 -1.01453,0.61092 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3"
+       id="path8168"
+       d="m 111.6009,112.54494 c 0.0742,-0.0753 0.15568,-0.14943 0.24669,-0.21256 0.0255,-0.0177 0.10894,-0.064 0.0817,-0.0481 -0.98172,0.57372 -1.3554,0.62003 -0.91471,0.55792 0.11497,0.039 0.15682,0.13628 0.25203,0.19449 0.0846,0.0306 0.18712,0.0603 0.28169,0.0364 0.16598,-0.0592 0.31837,-0.13799 0.48509,-0.19662 0.27061,-0.0796 0.41986,-0.10228 0.68943,-0.0328 0.11847,0.0325 0.23023,0.1078 0.36536,0.10088 0.44545,-0.0229 1.5357,-0.78739 1.58757,-0.8177 0.20291,-0.12811 0.36095,-0.28194 0.49129,-0.45667 0.0244,-0.0187 0.0281,-0.0489 0.0506,-0.0687 0.0363,-0.0318 0.0855,-0.0528 0.12324,-0.0836 0.0818,-0.0666 0.15197,-0.14386 0.22329,-0.21689 0.0899,-0.0804 0.16082,-0.17296 0.24975,-0.25402 0.0345,-0.0315 0.15225,-0.11545 0.11151,-0.0889 -0.28415,0.1849 -0.60887,0.33955 -0.84233,0.56445 -0.0491,0.0473 0.14884,0.0181 0.22067,0.0344 0.0736,0.0167 0.14282,0.0427 0.21422,0.0641 0.27744,0.1045 0.49492,0.209 0.60404,0.44206 0.0796,0.1852 0.1614,0.36964 0.24134,0.55482 0.0744,0.22335 0.33631,0.3272 0.57033,0.4349 0.26968,0.11532 0.54168,0.227 0.82876,0.31499 0.0317,0.009 0.0635,0.0176 0.0952,0.0263 0,0 0.99152,-0.64538 0.99152,-0.64538 v 0 c -0.0314,-0.007 -0.0628,-0.0142 -0.0942,-0.0214 -0.28781,-0.0805 -0.57296,-0.16425 -0.83334,-0.29059 -0.20733,-0.0995 -0.43144,-0.19771 -0.51068,-0.39074 -0.087,-0.18449 -0.14943,-0.37582 -0.24029,-0.55917 -0.14088,-0.26815 -0.36726,-0.36161 -0.69061,-0.48405 -0.0176,-0.005 -0.42776,-0.14327 -0.45104,-0.13511 -1.03004,0.36092 -1.06931,0.41601 -1.55617,0.9088 -0.14636,0.13112 -0.32388,0.24488 -0.42811,0.40012 -0.12263,0.15761 -0.28419,0.28941 -0.46707,0.40568 2.13243,-1.19891 0.65222,-0.3313 0.47908,-0.29312 -0.12862,0.0283 -0.24014,-0.0505 -0.34981,-0.0806 -0.31117,-0.10156 -0.40463,-0.10253 -0.73689,-0.0268 -0.12614,0.0323 -0.25491,0.0745 -0.36805,0.13185 -0.0206,0.01 -0.0358,0.0271 -0.0568,0.0371 -0.0151,0.007 -0.0334,0.009 -0.05,0.0139 -0.0122,0.005 -0.0242,0.0114 -0.0364,0.0165 -0.006,0.008 -0.009,0.0179 -0.0183,0.0226 -0.038,0.0184 -0.10982,-0.009 -0.15026,-0.003 -0.12156,-0.0374 -0.15596,-0.1778 -0.28477,-0.21479 -0.0322,-0.0113 -0.0654,-0.0487 -0.0968,-0.0338 -0.61582,0.29098 -1.02862,0.49164 -1.43688,0.88422 0,0 1.12911,-0.49205 1.12911,-0.49205 z" />
+    <path
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0.3"
+       id="path8170"
+       d="m 110.42559,116.21677 c 0.47229,-0.16317 0.92261,-0.37394 1.37223,-0.55582 0.33115,-0.13395 -0.65965,0.27124 -0.9883,0.40831 -0.0417,0.0174 0.0862,-0.0311 0.12979,-0.0459 0.13671,-0.0501 0.2851,0.018 0.40776,0.0611 0.0482,0.017 0.27257,0.10109 0.32122,0.11927 0.29494,0.11917 0.62534,0.16758 0.96157,0.16961 0.23359,-0.0288 0.4577,-0.0897 0.6627,-0.17421 1.14719,-0.47316 0.80357,-0.29916 1.23974,-0.52328 0.412,-0.16386 0.0977,-0.0392 -0.97712,0.405 -0.0241,0.01 0.043,-0.0291 0.0706,-0.0316 0.0725,-0.007 0.16573,0.0213 0.22849,0.0353 0.4417,0.11958 0.90915,0.13595 1.37582,0.14483 0.0764,-0.001 0.15284,-0.001 0.22903,-0.005 0.15096,-0.007 0.22684,-0.0159 0.36856,-0.0479 0.0966,-0.0218 0.17863,-0.0606 0.28507,-0.0562 0.056,0.002 0.10875,0.0197 0.16312,0.0297 0.25977,0.0904 0.46829,0.23819 0.7465,0.30395 0.16431,0.0388 0.30237,0.047 0.47187,0.0637 0.98365,-0.046 1.56378,-0.51802 2.02927,-1.04019 0.0647,-0.0664 0.13333,-0.13878 0.22739,-0.18698 0.0192,-0.01 0.0833,-0.032 0.0629,-0.0235 -0.34207,0.14379 -1.36727,0.57632 -1.02804,0.42914 0.37934,-0.16458 0.76562,-0.32091 1.14843,-0.48137 0.10162,-0.25867 0.12992,-0.52943 0.17013,-0.79581 0.0265,-0.0814 0.0607,-0.13482 0.1676,-0.17102 0.0247,-0.008 0.0999,-0.0312 0.0764,-0.0212 -1.01965,0.435 -1.42287,0.41149 -0.96219,0.42881 0.17621,0.10964 0.1911,0.36422 0.21208,0.52265 0.0326,0.1936 -0.007,0.39535 0.0604,0.5861 0.0166,0.0468 0.0445,0.0911 0.0667,0.13659 0.1307,0.15962 0.28691,0.30974 0.45525,0.45028 0.0658,0.0549 0.18454,0.1588 0.29895,0.17679 0.0675,0.0106 0.13797,-0.005 0.20696,-0.008 1.17034,-0.47757 0.93145,-0.28417 1.42798,-0.6311 0.0546,-0.0381 0.10619,-0.0785 0.162,-0.11569 0.0478,-0.0319 0.20557,-0.11426 0.14851,-0.0915 -1.09848,0.4392 -1.21269,0.45001 -0.75045,0.36312 0.27512,-0.0408 0.45039,0.1493 0.69864,0.17846 0.10976,0.0129 0.22233,0.006 0.33348,0.009 0.75523,-0.0485 1.49413,-0.17592 2.24485,-0.24703 0.0979,0.0105 0.29146,-0.0516 0.38897,5.7e-4 0.0675,0.0361 0.0575,0.15057 0.0628,0.19901 0.005,0.14384 -0.0118,0.32035 0.14872,0.42871 0.0322,0.0217 0.0726,0.0364 0.10889,0.0547 0.0604,0.0111 0.11921,0.0279 0.18108,0.0334 0.34936,0.0311 0.81839,-0.0211 1.16084,-0.0839 0.54106,-0.17647 0.40817,-0.12724 1.33547,-0.57942 0.0866,-0.0422 0.23625,-0.24391 0.34057,-0.31836 -0.33267,0.14599 -0.68906,0.26756 -0.99802,0.43797 -0.0406,0.0224 0.10104,0.0157 0.14752,0.0311 0.0813,0.027 0.36086,0.15674 0.42903,0.18754 0.13098,0.0591 0.26227,0.118 0.39332,0.17711 0.19079,0.0874 0.38926,0.16167 0.60781,0.20545 0.0826,0.0159 0.16728,0.0152 0.25197,0.0142 0,0 1.02856,-0.53421 1.02856,-0.53421 v 0 c -0.079,5.6e-4 -0.15798,0.004 -0.23695,0.002 -0.22425,-0.0191 -0.42839,-0.0831 -0.62525,-0.16054 -0.2847,-0.11433 -0.55096,-0.23904 -0.81624,-0.37477 -0.0541,-0.0277 -0.10182,-0.0983 -0.16405,-0.0814 -0.41554,0.11321 -0.78535,0.298 -1.17803,0.44701 -0.0685,0.0708 -0.13119,0.14494 -0.20854,0.21126 -0.0363,0.0311 -0.16605,0.10703 -0.11455,0.0899 0.59451,-0.19734 1.27886,-0.52729 0.78262,-0.29122 -0.40245,0.0981 -0.83912,0.14448 -1.26294,0.10275 -0.0285,-0.0105 -0.0597,-0.0181 -0.0856,-0.0317 -0.15211,-0.0801 -0.0994,-0.2645 -0.11929,-0.37844 -0.0137,-0.0938 -0.0173,-0.21261 -0.11994,-0.2847 -0.12405,-0.0871 -0.33375,-0.0224 -0.47599,-0.0177 -0.74739,0.0845 -1.48484,0.21511 -2.24036,0.26252 -0.0927,-3.8e-4 -0.18613,0.008 -0.27799,-7.1e-4 -0.24696,-0.0232 -0.45308,-0.2394 -0.73157,-0.22051 -0.0554,0.004 -0.11657,-0.004 -0.16628,0.0137 -0.41308,0.15006 -0.81446,0.31637 -1.21159,0.4869 -0.0537,0.023 -0.0913,0.0611 -0.13657,0.092 -0.0536,0.0366 -0.10455,0.0752 -0.16011,0.11022 -0.0596,0.0376 -0.25711,0.13182 -0.18511,0.10759 0.2958,-0.0995 0.57423,-0.22342 0.86134,-0.33513 -0.0511,0.0175 -0.0969,0.0487 -0.15341,0.0527 -0.11753,0.008 -0.22993,-0.0849 -0.29267,-0.13264 -0.16706,-0.1272 -0.31025,-0.27207 -0.41721,-0.42867 -0.0173,-0.0418 -0.0391,-0.0827 -0.0519,-0.12523 -0.0584,-0.19306 -0.0152,-0.39243 -0.0488,-0.58712 -0.0365,-0.21311 -0.0723,-0.44957 -0.27099,-0.61935 -0.48526,-0.16635 -0.0807,-0.0487 -1.26267,0.40402 -0.13025,0.0499 -0.15628,0.17013 -0.17344,0.26235 -0.0158,0.201 -0.0299,0.49134 -0.16111,0.67041 -0.0181,0.0247 -0.0506,0.0425 -0.076,0.0638 0.34083,-0.13818 1.35828,-0.55883 1.02247,-0.41454 -0.70939,0.30479 -1.05849,0.2973 -1.38623,0.69909 -0.10905,0.1263 -0.22055,0.25347 -0.3665,0.36056 -0.0571,0.0419 -0.25882,0.14035 -0.18411,0.11626 1.36417,-0.4399 1.06889,-0.37219 0.64394,-0.29339 -0.15448,-0.0103 -0.29976,-0.0149 -0.4503,-0.0451 -0.28213,-0.0567 -0.49654,-0.20289 -0.73952,-0.31129 -0.12505,-0.042 -0.2072,-0.0889 -0.35219,-0.0705 -0.0518,0.006 -0.0944,0.0333 -0.14262,0.0482 -0.19111,0.0591 -0.38566,0.0852 -0.59484,0.0872 -0.44803,7.2e-4 -0.89855,-0.0153 -1.31991,-0.13565 -0.0818,-0.0257 -0.21149,-0.0876 -0.30502,-0.0912 -0.0138,-5.7e-4 -0.0256,0.008 -0.0377,0.0126 -1.11973,0.4595 -0.77727,0.28995 -1.18848,0.4956 -0.3811,0.18239 -0.0331,0.0142 0.90265,-0.36404 0.0439,-0.0177 -0.0852,0.0386 -0.12895,0.0563 -0.15904,0.0647 -0.32691,0.11304 -0.50122,0.15281 -0.32101,0.0243 -0.64055,-0.0277 -0.92939,-0.12932 -0.15663,-0.0569 -0.30861,-0.11845 -0.46257,-0.17882 -0.0511,-0.02 -0.16444,-0.0671 -0.2275,-0.079 -0.0249,-0.005 -0.0513,-0.002 -0.077,-0.004 -0.45968,0.14865 -0.83057,0.33575 -1.30769,0.52209 -0.33081,0.1292 0.65352,-0.26863 0.98049,-0.40269 0.0604,-0.0248 -0.22156,0.0914 -0.17946,0.0763 0,0 -1.00068,0.56077 -1.00068,0.56077 z" />
+    <circle
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path8172-2"
+       cx="109.44193"
+       cy="115.70985"
+       r="0.43019626" />
+    <circle
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path8172-2-9"
+       cx="109.44193"
+       cy="112.60403"
+       r="0.43019626" />
+    <circle
+       style="opacity:0.5;fill:#383838;fill-opacity:1;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path8172-2-3"
+       cx="109.44193"
+       cy="109.4982"
+       r="0.43019626" />
+  </g>
+</svg>

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: workshop      # DON'T CHANGE THIS.
-root: .               # DON'T CHANGE THIS EITHER.  (THANK YOU.)
+root: .               # DON'T CHANGE THIS EITHER.
+curriculum: "Instructor Training" # DON'T CHANGE THIS EITHER. (THANK YOU.)
 venue: "FIXME"        # brief name of the institution that hosts the workshop without address (e.g., "Euphoric State University")
 address: "FIXME"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria"), videoconferencing URL, or 'online'
 country: "FIXME"      # "W3" for centrally organized online trainings or lowercase two-letter ISO country code such as "fr" of the host institution if applicable (see https://en.wikipedia.org/wiki/ISO_3166-1)
@@ -57,11 +58,11 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
 -->
 
 <p>
-<a href="{{ site.carpentries_site }}">The Carpentries</a> is a community of practice centered around teaching foundational 
-  coding and data science skills to researchers worldwide. This Instructor Training 
-  event is designed to prepare trainees to certify and participate as Carpentries 
-  Instructors. However, much of our curriculum focuses on educational principles that 
-  apply across a wide variety of contexts. We also welcome participants who do not plan 
+<a href="{{ site.carpentries_site }}">The Carpentries</a> is a community of practice centered around teaching foundational
+  coding and data science skills to researchers worldwide. This Instructor Training
+  event is designed to prepare trainees to certify and participate as Carpentries
+  Instructors. However, much of our curriculum focuses on educational principles that
+  apply across a wide variety of contexts. We also welcome participants who do not plan
   to certify but simply wish to become a better teacher.
 </p>
 
@@ -79,7 +80,7 @@ not be learning:</p>
 * How to program in R or Python, use Git or SQL, or any of the other topics taught in  <a href="{{ site.dc_site }}">Data Carpentry</a>,
   <a href="{{ site.lc_site }}">Library Carpentry</a>, or
   <a href="{{ site.swc_site }}">Software Carpentry</a> workshops.
-* How to create your own lessons from scratch (although you will have a good start on the principles behind that sort of work if you are inspired to learn more).
+* How to create your own lessons from scratch. However, this Instructor Training serves as a good precursor to [The Carpentries Lesson Developer Training]({{ site.lessondev_training_site }}).
 
 
 <p>

--- a/index.md.cldt
+++ b/index.md.cldt
@@ -1,0 +1,307 @@
+---
+layout: workshop      # DON'T CHANGE THIS.
+root: .               # DON'T CHANGE THIS EITHER.
+curriculum: "Collaborative Lesson Development Training" # DON'T CHANGE THIS EITHER. (THANK YOU.)
+part: "FIXME"         # The part of the lesson development training curriculum being taught at this event: "1" or "2"
+venue: "FIXME"        # brief name of the institution that hosts the workshop without address (e.g., "Euphoric State University")
+address: "FIXME"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria"), videoconferencing URL, or 'online'
+country: "FIXME"      # "W3" for centrally organized online trainings or lowercase two-letter ISO country code such as "fr" of the host institution if applicable (see https://en.wikipedia.org/wiki/ISO_3166-1)
+language: "FIXME"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/ISO_639-1)
+latitude: "45"        # decimal latitude of training venue (use https://www.latlong.net/)
+longitude: "-1"       # decimal longitude of the training venue (use https://www.latlong.net)
+humandate: "FIXME"    # human-readable dates for the workshop (e.g., "Feb 17-18, 2020")
+humantime: "FIXME"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
+startdate: FIXME      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
+enddate: FIXME        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
+instructor: ["FIXME"] # boxed, comma-separated list of trainers' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
+helper: ["FIXME"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
+contact: ["fixme@example.org"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
+etherpad:             # optional: URL for the workshop CodiMD/Etherpad if there is one
+eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
+---
+
+<!-- See instructions in the comments below for how to edit specific sections of this workshop template. When you are done, rename the file to index.md (replacing the default version of that file, used for Instructor Trainig events)-->
+
+<!--
+  HEADER
+
+  Edit the values in the block above to be appropriate for your workshop.
+  If the value is not 'true', 'false', 'null', or a number, please use
+  double quotation marks around the value, unless specified otherwise.
+  And run 'tools/check' *before* committing to make sure that changes are good.
+-->
+
+<img src="fig/CLDT-hex-sticker.svg" alt="" width="20%"/>{: style="float: right"}
+
+<!--
+  EVENTBRITE
+
+  This block includes the Eventbrite registration widget if
+  'eventbrite' has been set in the header.  You can delete it if you
+  are not using Eventbrite, or leave it in, since it will not be
+  displayed if the 'eventbrite' field in the header is not set.
+-->
+{% if page.eventbrite %}
+<iframe
+  src="https://www.eventbrite.com/tickets-external?eid={{page.eventbrite}}&ref=etckt"
+  frameborder="0"
+  width="100%"
+  height="248px"
+  scrolling="auto">
+</iframe>
+{% endif %}
+
+<h2 id="general">General Information</h2>
+
+<!--
+  INTRODUCTION
+
+  Edit the general explanatory paragraph below if you want to change
+  the pitch.
+-->
+
+<p>
+<a href="{{ site.carpentries_site }}">The Carpentries</a> is a community of practice centered around teaching foundational
+  coding and data science skills to researchers worldwide.
+  This Lesson Developer Training teaches good practices in lesson design and development, and collaboration skills, using open source infrastructure.
+  The target audience is groups of collaborators with an idea for a new lesson they would like to create together, especially if that lesson is intended for short-format training (e.g. part or all of a two-day workshop).
+</p>
+
+<p>After attending Carpentries Lesson Developer Training, participants will be able to:</p>
+
+* collaboratively develop and publish lessons using The Carpentries lesson infrastructure (aka [The Carpentries Workbench](https://carpentries.github.io/workbench/))
+* identify and characterise the target audience for a lesson.
+* define SMART learning objectives.
+* explain the pedagogical value of authentic tasks.
+* create exercises for formative assessment.
+* explain how considerations of cognitive load can influence the pacing, length, and organisation of a lesson.
+* configure and maintain accessible and usable lesson repositories using best practices, readily available for collaboration.
+* identify and correct accessibility issues in a Carpentries lesson.
+* update and improve lesson material guided by feedback and reflection from teaching.
+* review and provide constructive feedback on lessons.
+
+
+<p> Because we have only limited time, some things are beyond the scope of this training. We will
+not be learning:</p>
+
+* How to track changes and manage branches with Git. To learn these skills, we recommend that you follow the lessons from Library Carpentry and Software Carpentry:
+    * [Library Carpentry: Introduction to Git](https://librarycarpentry.org/lc-git/)
+    * [Version Control with Git](https://swcarpentry.github.io/git-novice/)
+* How to teach a lesson in a workshop. [The Carpentries Instructor Training]({{ site.training_site }}) teaches foundational skills for excellent teaching.
+
+<p> Lesson Developer Training events are hands-on throughout:
+short lessons are interspersed with frequent practical exercises, through which trainees construct the basic outline of their lesson and begin to fill in some of the detail.
+For more information, see <a href="{{ site.lessondev_training_site }}">the Lesson Developer Training Curriculum</a>.
+</p>
+
+<p>
+Lesson Developer Training takes place in two parts separated by an extended break.
+</p>
+
+{% if page.part == "1" %}
+<p>
+This first part focusses on backward lesson design and techniques for the development of effective exercises and accessible lesson content.
+Trainees will define the target audience and intended learning outcomes of their lesson,
+produce an outline of the lesson content and narrative,
+prepare exercises and examples for a chosen section,
+and start building this material into an open source lesson website.
+</p>
+<p>
+Trainees are required to trial part of their new lesson with a real audience during the break between this first part and the conclusion of the training.
+When they return for the second and final part of the training, participants will reflect on this experience and discuss how they will approach the remaining stages of lesson development.
+</p>
+{% elsif page.part == "2" %}
+<p>
+In this second and final part of the training, participants will reflect on the experience of trialling their new lesson content,
+the remaining stages of lesson development,
+and some techniques and tools they can use to collaborate more effectively on their open source lesson project.
+</p>
+{% else %}
+<div class="alert alert-warning">
+You have not specified which part of Lesson Developer Training will be taught at this event.
+The training part is configured in the <code>part</code> field of the YAML header for this page (<code>index.md</code>).
+Expected values for <code>part</code> are <code>"1"</code> and <code>"2"</code>.
+The current value is: <code>{{ page.part }}</code>.
+</div>
+{% endif %}
+
+<h3>Code of Conduct</h3>
+
+All participants are required to abide by The Carpentries <a href="{{
+site.swc_site }}/conduct/">Code of Conduct</a>.
+
+
+
+{% assign begin_address = page.address | slice: 0, 4 | downcase  %}
+{% if page.address == "online" %}
+{% assign online = "true_private" %}
+{% elsif begin_address contains "http" %}
+{% assign online = "true_public" %}
+{% else %}
+{% assign online = "false" %}
+{% endif %}
+<!--
+  LOCATION
+
+  This block displays the address and links to maps showing directions
+  if the latitude and longitude of the workshop have been set.  You
+  can use http://itouchmap.com/latlong.html to find the lat/long of an
+  address.
+  -->
+<h3 id="where">Where</h3>
+
+
+{% if online == "false" %}
+<p id="venue">
+  {{page.address}}.
+  {% if page.latitude and page.longitude %}
+  Get directions with
+  <a href="//www.openstreetmap.org/?mlat={{page.latitude}}&mlon={{page.longitude}}&zoom=16">OpenStreetMap</a>
+  or
+  <a href="//maps.google.com/maps?q={{page.latitude}},{{page.longitude}}">Google Maps</a>.
+  {% endif %}
+</p>
+{% elsif online == "true_public" %}
+<p id="venue">
+  Online at <a href="{{page.address}}">{{page.address}}</a>.
+  The training will be conducted using the Zoom video conferencing platform. No log-in is needed.
+  However, if you have not used Zoom before, please click the link a few minutes early as it may prompt you to
+  install the Zoom app or browser extension. You should have received a connection link in the same email that
+  directed you to this website. If you found this page by another means and did not receive the connection link,
+  please check your spam folder and email instructor.training@carpentries.org with your Trainers (contact details below) on cc.
+</p>
+{% elsif online == "true_private" %}
+<p id="venue">
+  This training will take place online.
+  The instructors will provide you with the information you will need to connect to this meeting.
+</p>
+{% endif %}
+
+{% if online == "false" %}
+
+<h4 id="accessibility">Accessibility</h4>
+
+We are committed to making this workshop
+accessible to everybody.
+Workshop organisers have checked that:
+
+<ul>
+  <li>The room is wheelchair / scooter accessible.</li>
+  <li>Accessible restrooms are available.</li>
+</ul>
+
+Materials will be provided in advance of the workshop.
+If we can help make learning easier for you in any way by
+providing additional support, accommodations, or assistance,
+please get in touch (using contact details below) and we will attempt to provide them.
+
+{% endif %}
+
+<h3>How to Prepare for Lesson Developer Training</h3>
+
+<p>
+Before the training, please <strong>complete our pre-training survey</strong>.
+You will receive a custom link for your event when you receive your connection information.
+</p>
+<p>Before joining the first training session, take a few minutes to think about and note down your answers to the following questions:
+<ol>
+    <li>What is the topic of the lesson that you plan to develop based on this training?</li>
+    <li>Have you created training material on this topic before?</li>
+    <li>What is motivating you to create this lesson?</li>
+</ol>
+</p>
+<h4>Prerequisite Knowledge</h4>
+<p>
+Before joining Collaborative Lesson Development Training, participants should be able to:
+<ol>
+  <li>write formatted text - bold and italic, headings, links, bullet point and numbered lists - with Markdown.</li>
+  <li>log into <a href="https://github.com/" target="_blank">GitHub.com</a> and create and edit files using the GitHub web interface.</li>
+</ol>
+</p>
+<p>
+If you need to learn or refresh these skills before the training,
+visit our <a href="https://carpentries.github.io/lesson-development-training/markdown-github-primer.html">Primer on Markdown and GitHub</a> for links to resources to help learn these skills.
+</p>
+
+<h3>Attendance and Cancellation</h3>
+Trainees who miss more than 1 hour of the training may be marked absent.
+Lesson Developer certification cannot be completed without full attendance at
+an Instructor Training event. If you unexpectedly need to miss more than
+1 hour of your event, please contact your Trainers (contact info below).
+
+For events in which registration occurs through The Carpentries via Eventbrite,
+cancellation may be performed in Eventbrite up to the start of the event.
+Cancelled seats cannot be filled after the 1 week registration deadline for these events,
+so we ask that you only cancel if absolutely necessary.
+
+<h3 id="contact">Contact</h3>
+<p>
+Please email
+{% if page.contact %}
+  {% for contact in page.contact %}
+    {% if forloop.last and page.contact.size > 1 %}
+      or
+    {% else %}
+      {% unless forloop.first %}
+      ,
+      {% endunless %}
+    {% endif %}
+    <a href='mailto:{{contact}}'>{{contact}}</a>
+  {% endfor %}
+{% else %}
+  to-be-announced
+{% endif %}
+for more information.
+</p>
+
+<hr/>
+
+
+<hr/>
+
+<h2 id="materials" name="materials">Training Materials and Schedule</h2>
+
+<p>
+  Please see <a href="{{ site.lessondev_training_site }}/instructor/index.html#schedule">the Lesson Developer Training Curriculum</a> for course material and sample schedule for a 6 half-day event.
+</p>
+<p>
+  The training is divided into two parts and includes an extended break between the two parts.
+  Part 1 ends with a wrap-up session after the section on <em>Preparing to Teach</em>.
+  Part 2 begins with a reflection on the lesson trial runs trainees completed during the break, then switches focus to discuss effective strategies and tools for collaboration.
+</p>
+
+
+<!--
+  CODIMD FOR LESSON DEVELOPER TRAINING
+  A template CodiMD for notetaking at Collaborative Lesson Development Training
+  is available at https://codimd.carpentries.org/cldt-notes-template.
+  To create a CodiMD for your training, navigate to
+      http://codimd.carpentries.org/YYYY-MM-DD-cldt-site
+  where 'YYYY-MM-DD-cldt-site' is the identifier for your training,
+  e.g., '2015-06-10-cldt-esu'.
+  Then copy the contents of the template CodiMD and paste it into your new document.
+  If you find that the template is outdated or needs fixing, please open an issue
+  on the training curriculum repository: https://github.com/carpentries/lesson-development-training/issues/new
+-->
+
+{% if page.etherpad %}
+<hr/>
+
+<p id="codimd">
+  <strong>CodiMD:</strong> <a href="{{page.etherpad}}">{{page.etherpad}}</a>.
+  <br/>
+  We will use this CodiMD document for chatting, taking notes, and sharing URLs and bits of code during the training.
+</p>
+
+{% endif %}
+
+<h2 id="pre_workshop_survey">Surveys</h2>
+
+<p>
+  Before attending the workshop, please fill out <a href="{{ site.lessondev_pre_survey }}{{ site.github.project_title }}">our pre-training survey</a>.
+</p>
+
+
+<p>
+  After the workshop, please fill out <a href="{{ site.lessondev_post_survey }}{{ site.github.project_title }}">our post-training survey</a>.
+</p>

--- a/index.md.cldt
+++ b/index.md.cldt
@@ -67,6 +67,8 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
   The target audience is groups of collaborators with an idea for a new lesson they would like to create together, especially if that lesson is intended for short-format training (e.g. part or all of a two-day workshop).
 </p>
 
+<h3>What is taught in this training?</h3>
+
 <p>After attending Carpentries Lesson Developer Training, participants will be able to:</p>
 
 * collaboratively develop and publish lessons using The Carpentries lesson infrastructure (aka [The Carpentries Workbench](https://carpentries.github.io/workbench/))
@@ -80,6 +82,7 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
 * update and improve lesson material guided by feedback and reflection from teaching.
 * review and provide constructive feedback on lessons.
 
+<h3>What is <em>not</em> taught in this training?</h3>
 
 <p> Because we have only limited time, some things are beyond the scope of this training. We will
 not be learning:</p>
@@ -89,13 +92,16 @@ not be learning:</p>
     * [Version Control with Git](https://swcarpentry.github.io/git-novice/)
 * How to teach a lesson in a workshop. [The Carpentries Instructor Training]({{ site.training_site }}) teaches foundational skills for excellent teaching.
 
+
+<h3>What to expect in this part of the training</h3>
+
 <p> Lesson Developer Training events are hands-on throughout:
 short lessons are interspersed with frequent practical exercises, through which trainees construct the basic outline of their lesson and begin to fill in some of the detail.
 For more information, see <a href="{{ site.lessondev_training_site }}">the Lesson Developer Training Curriculum</a>.
 </p>
 
 <p>
-Lesson Developer Training takes place in two parts separated by an extended break.
+The training takes place in two parts separated by an extended break.
 </p>
 
 {% if page.part == "1" %}


### PR DESCRIPTION
This PR is a different way to approach the problem of adding support for Collaborative Lesson Development Training with this template. 

Unlike #82, which integrates CLDT-related content into the existing `index.md` for Instructor Training, this adds a second `index.md` template (called `index.md.cldt`) that can be configured and then renamed to replace the `index.md` for Instructor Training.

This has the advantage of keeping things as they were for Instructor Trainers, who will be using the template much more often than we will for CLDT for the foreseeable future.