### PR TITLE
Update language workshops v trainings

### DIFF
--- a/index.md
+++ b/index.md
@@ -147,21 +147,21 @@ site.swc_site }}/conduct/">Code of Conduct</a>.
 
 <h4 id="accessibility">Accessibility</h4>
 
-We are committed to making this workshop
+We are committed to making this training
 accessible to everybody.
-Workshop organisers have checked that:
+Organisers have checked that:
 
 <ul>
   <li>The room is wheelchair / scooter accessible.</li>
   <li>Accessible restrooms are available.</li>
 </ul>
 
-Materials will be provided in advance of the workshop.
+Materials will be provided in advance of the event.
 
 We do not require participants to provide documentation of disabilities or disclose any unnecessary personal information. 
 However, we do want to help create an inclusive, accessible experience for all participants.
 We encourage you to share any information that would be helpful to make your Carpentries experience accessible.
-To request an accommodation for this workshop, please fill out the
+To request an accommodation for this training, please fill out the
 <a href="https://carpentries.typeform.com/to/B2OSYaD0">accommodation request form</a>.
 If you have questions or need assistance with the accommodation form please <a href="mailto:team@carpentries.org">email us</a>.
 
@@ -233,7 +233,7 @@ for more information.
 <h2 id="preparation" name="preparation">Preparation</h2>
 
 <p>
-  Please read the following before the workshop begins:
+  Please read the following before the training begins:
 </p>
 <ol>
   <li><a href="{{ site.training_site }}/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
@@ -264,7 +264,7 @@ for more information.
 <hr/>
 
 <!--
-NOTE: This space can be customized to reflect the unique schedule of your workshop. If you would like it to display,
+NOTE: This space can be customized to reflect the unique schedule of your training. If you would like it to display,
 adjust the times and titles, then delete the characters above and below that serve to comment it out.
 -->
 
@@ -402,10 +402,10 @@ FOUR DAY SCHEDULE
 <h2 id="pre_workshop_survey">Surveys</h2>
 
 <p>
-  Before attending the workshop, please fill out <a href="{{ site.instructor_pre_survey }}{{ site.github.project_title }}">our pre-training survey</a>.
+  Before attending the training, please fill out <a href="{{ site.instructor_pre_survey }}{{ site.github.project_title }}">our pre-training survey</a>.
 </p>
 
 
 <p>
-  After the workshop, please fill out <a href="{{ site.instructor_post_survey }}{{ site.github.project_title }}">our post-training survey</a>.
+  After the training, please fill out <a href="{{ site.instructor_post_survey }}{{ site.github.project_title }}">our post-training survey</a>.
 </p>

--- a/index.md.cldt
+++ b/index.md.cldt
@@ -20,12 +20,12 @@ etherpad:             # optional: URL for the workshop CodiMD/Etherpad if there 
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
 
-<!-- See instructions in the comments below for how to edit specific sections of this workshop template. When you are done, rename the file to index.md (replacing the default version of that file, used for Instructor Trainig events)-->
+<!-- See instructions in the comments below for how to edit specific sections of this training event template. When you are done, rename the file to index.md (replacing the default version of that file, used for Instructor Trainig events)-->
 
 <!--
   HEADER
 
-  Edit the values in the block above to be appropriate for your workshop.
+  Edit the values in the block above to be appropriate for your event.
   If the value is not 'true', 'false', 'null', or a number, please use
   double quotation marks around the value, unless specified otherwise.
   And run 'tools/check' *before* committing to make sure that changes are good.
@@ -150,7 +150,7 @@ site.swc_site }}/conduct/">Code of Conduct</a>.
   LOCATION
 
   This block displays the address and links to maps showing directions
-  if the latitude and longitude of the workshop have been set.  You
+  if the latitude and longitude of the event have been set.  You
   can use http://itouchmap.com/latlong.html to find the lat/long of an
   address.
   -->
@@ -308,10 +308,10 @@ for more information.
 <h2 id="pre_workshop_survey">Surveys</h2>
 
 <p>
-  Before attending the workshop, please fill out <a href="{{ site.lessondev_pre_survey }}{{ site.github.project_title }}">our pre-training survey</a>.
+  Before attending the training, please fill out <a href="{{ site.lessondev_pre_survey }}{{ site.github.project_title }}">our pre-training survey</a>.
 </p>
 
 
 <p>
-  After the workshop, please fill out <a href="{{ site.lessondev_post_survey }}{{ site.github.project_title }}">our post-training survey</a>.
+  After the training, please fill out <a href="{{ site.lessondev_post_survey }}{{ site.github.project_title }}">our post-training survey</a>.
 </p>

--- a/index.md.cldt
+++ b/index.md.cldt
@@ -187,23 +187,24 @@ site.swc_site }}/conduct/">Code of Conduct</a>.
 
 <h4 id="accessibility">Accessibility</h4>
 
-We are committed to making this workshop
+We are committed to making this training
 accessible to everybody.
-Workshop organisers have checked that:
+Organisers have checked that:
 
 <ul>
   <li>The room is wheelchair / scooter accessible.</li>
   <li>Accessible restrooms are available.</li>
 </ul>
 
-Materials will be provided in advance of the workshop.
+Materials will be provided in advance of the event.
 
-We do not require participants to provide documentation of disabilities or disclose any unnecessary personal information.
+We do not require participants to provide documentation of disabilities or disclose any unnecessary personal information. 
 However, we do want to help create an inclusive, accessible experience for all participants.
 We encourage you to share any information that would be helpful to make your Carpentries experience accessible.
-To request an accommodation for this workshop, please fill out the
+To request an accommodation for this training, please fill out the
 <a href="https://carpentries.typeform.com/to/B2OSYaD0">accommodation request form</a>.
 If you have questions or need assistance with the accommodation form please <a href="mailto:team@carpentries.org">email us</a>.
+
 {% endif %}
 
 <h3>How to Prepare for Lesson Developer Training</h3>


### PR DESCRIPTION
I've been asked to limit the use of "workshop" to swc/dc/lc events, so updating here accordingly. I was reminded about this by the new accessibility form language, but upon correction found that this whole template was never updated to reflect this language choice. I think this takes care of the public-facing instances.

