### PR TITLE
Make most a11y info appear for online events too

### DIFF
--- a/index.md
+++ b/index.md
@@ -143,18 +143,17 @@ site.swc_site }}/conduct/">Code of Conduct</a>.
 </p>
 {% endif %}
 
-{% if online == "false" %}
-
 <h4 id="accessibility">Accessibility</h4>
 
 We are committed to making this training
 accessible to everybody.
-Organisers have checked that:
+{% if online == "false" %}Organisers have checked that:
 
 <ul>
   <li>The room is wheelchair / scooter accessible.</li>
   <li>Accessible restrooms are available.</li>
 </ul>
+{% endif %}
 
 Materials will be provided in advance of the event.
 
@@ -164,8 +163,6 @@ We encourage you to share any information that would be helpful to make your Car
 To request an accommodation for this training, please fill out the
 <a href="https://carpentries.typeform.com/to/B2OSYaD0">accommodation request form</a>.
 If you have questions or need assistance with the accommodation form please <a href="mailto:team@carpentries.org">email us</a>.
-
-{% endif %}
 
 <h3>How to Prepare for Instructor Training</h3>
 

--- a/index.md.cldt
+++ b/index.md.cldt
@@ -183,18 +183,17 @@ site.swc_site }}/conduct/">Code of Conduct</a>.
 </p>
 {% endif %}
 
-{% if online == "false" %}
-
 <h4 id="accessibility">Accessibility</h4>
 
 We are committed to making this training
 accessible to everybody.
-Organisers have checked that:
+{% if online == "false" %}Organisers have checked that:
 
 <ul>
   <li>The room is wheelchair / scooter accessible.</li>
   <li>Accessible restrooms are available.</li>
 </ul>
+{% endif %}
 
 Materials will be provided in advance of the event.
 
@@ -204,8 +203,6 @@ We encourage you to share any information that would be helpful to make your Car
 To request an accommodation for this training, please fill out the
 <a href="https://carpentries.typeform.com/to/B2OSYaD0">accommodation request form</a>.
 If you have questions or need assistance with the accommodation form please <a href="mailto:team@carpentries.org">email us</a>.
-
-{% endif %}
 
 <h3>How to Prepare for Lesson Developer Training</h3>
 


### PR DESCRIPTION
Moving the `{% if %}` and `{% endif %}` tags to make most of the Accessibility info, including the link to the Accommodation Request Form visible for online events as well as in-person training.