### PR TITLE
specify bundler version

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Install GitHub Pages, Bundler, and kramdown gems
         run: |
-          gem install github-pages bundler kramdown kramdown-parser-gfm
+          gem install github-pages bundler:2.4.22 kramdown kramdown-parser-gfm
 
       - name: Install Python modules
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install GitHub Pages, Bundler, and kramdown gems
         run: |
-          gem install github-pages bundler kramdown kramdown-parser-gfm
+          gem install github-pages bundler:2.4.22 kramdown kramdown-parser-gfm
 
       - name: Install Python modules
         run: |


### PR DESCRIPTION
Specifying bundler v2.4.22 to permit older version of Ruby in website builds.