### PR TITLE
Add row split between Days 1/2 and Days 3/4

### DIFF
--- a/index.md
+++ b/index.md
@@ -341,6 +341,8 @@ FOUR DAY SCHEDULE
       <tr> <td>16:50</td> <td>Finish day 2</td> </tr>
     </table>
   </div>
+</div>
+<div class="row">  
   <div class="col-md-6">
     <h3>Day 3</h3>
     <table class="table table-striped">


### PR DESCRIPTION
For four-day workshops, the schedule is often rendered oddly (it looks like three rows, given the way it wraps on the screen). Splitting the row div into two separate divs creates a workaround.