### PR TITLE
Fix broken/outdated links to Annual Report and Science of Learning

### DIFF
--- a/index.md
+++ b/index.md
@@ -233,7 +233,7 @@ for more information.
   Please read the following before the training begins:
 </p>
 <ol>
-  <li><a href="{{ site.training_site }}/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
+  <li><a href="https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
   <li><a href="https://carpentries.org/files/reports/AnnualReport2023.pdf">The Carpentries 2023 Annual Report</a></li>
 </ol>
 <p>

--- a/index.md
+++ b/index.md
@@ -173,7 +173,7 @@ Before your training, please visit our Preparing for Instructor Training page fo
   <li>Please read the following:</li>
     <ul>
       <li><a href="https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
-      <li><a href="https://carpentries.org/files/reports/AnnualReport2023.pdf">The Carpentries Annual Report</a></li>
+      <li><a href="https://carpentries.org/files/reports/AnnualReport2023.pdf">The Carpentries 2023 Annual Report</a></li>
     </ul>
 </ol>
 
@@ -234,7 +234,7 @@ for more information.
 </p>
 <ol>
   <li><a href="{{ site.training_site }}/papers/science-of-learning-2015.pdf">The Science of Learning</a></li>
-  <li><a href="https://carpentries.org/files/reports/2021%20Carpentries%20Annual%20Report_Final.pdf">The Carpentries 2021 Annual Report</a></li>
+  <li><a href="https://carpentries.org/files/reports/AnnualReport2023.pdf">The Carpentries 2023 Annual Report</a></li>
 </ol>
 <p>
   Please also read through <em>one</em> episode of one of The Carpentries lessons below


### PR DESCRIPTION
Currently, the links to the Annual Report and the “Science of Learning” document are included twice in the template—first in the “How to Prepare for Instructor Training” subsection and then again in the “Preparation” section. This PR fixes two issues in the “Preparation” section:

* Updates the Annual Report link to the 2023 version
* Fixes a broken link to the “Science of Learning” document

The links in the “How to Prepare for Instructor Training” subsection were already updated/fixed in #94 and #65, respectively.